### PR TITLE
adding fzf plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `go`        | Provides `gofmt` and `goimports` support for Go files | https://github.com/micro-editor/go-plugin           |
 | `fish`      | Provides `fishfmt` support for Fish files             | https://github.com/onodera-punpun/micro-fish-plugin |
 | `wc`        | Plugin to count words/characters                      | https://github.com/adamnpeace/micro-wc-plugin       |
+| `fzf`       | Provides `fzf` support for opening files              | https://github.com/samdmarshall/micro-fzf-plugin    |
 
 ## Adding your own plugin
 

--- a/channel.json
+++ b/channel.json
@@ -5,12 +5,15 @@
   // Fish plugin
   "https://raw.githubusercontent.com/onodera-punpun/micro-fish-plugin/master/repo.json",
 
+  // fzf plugin
+  "https://raw.githubusercontent.com/samdmarshall/micro-fzf-plugin/master/repo.json",
+
   // Go plugin
   "https://raw.githubusercontent.com/micro-editor/go-plugin/master/repo.json",
 
   // Snippets plugin
   "https://raw.githubusercontent.com/boombuler/microsnippets/master/repo.json",
-  
+
   // wc plugin
   "https://raw.githubusercontent.com/adamnpeace/micro-wc-plugin/master/repo.json"
 ]


### PR DESCRIPTION
adding a new plugin that allows `fzf` to be use to select files to open in micro.