### PR TITLE
Add EditorConfig plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,15 @@ This repository contains the 'channel.json' file which lists all official micro 
 
 ## Plugins
 
-| Plugin      | Description                                           | Link                                                |
-| ----------- | ----------------------------------------------------- | --------------------------------------------------- |
-| `comment`   | Plugin to auto comment or uncomment lines             | https://github.com/micro-editor/comment-plugin      |
-| `snippets`  | Provides snippets functionality                       | https://github.com/boombuler/microsnippets          |
-| `go`        | Provides `gofmt` and `goimports` support for Go files | https://github.com/micro-editor/go-plugin           |
-| `fish`      | Provides `fishfmt` support for Fish files             | https://github.com/onodera-punpun/micro-fish-plugin |
-| `wc`        | Plugin to count words/characters                      | https://github.com/adamnpeace/micro-wc-plugin       |
-| `fzf`       | Provides `fzf` support for opening files              | https://github.com/samdmarshall/micro-fzf-plugin    |
+| Plugin         | Description                                           | Link                                                |
+| -------------- | ----------------------------------------------------- | --------------------------------------------------- |
+| `comment`      | Plugin to auto comment or uncomment lines             | https://github.com/micro-editor/comment-plugin      |
+| `snippets`     | Provides snippets functionality                       | https://github.com/boombuler/microsnippets          |
+| `go`           | Provides `gofmt` and `goimports` support for Go files | https://github.com/micro-editor/go-plugin           |
+| `fish`         | Provides `fishfmt` support for Fish files             | https://github.com/onodera-punpun/micro-fish-plugin |
+| `wc`           | Plugin to count words/characters                      | https://github.com/adamnpeace/micro-wc-plugin       |
+| `fzf`          | Provides `fzf` support for opening files              | https://github.com/samdmarshall/micro-fzf-plugin    |
+| `editorconfig` | EditorConfig Support for micro                        | https://github.com/10sr/editorconfig-micro          |
 
 ## Adding your own plugin
 

--- a/channel.json
+++ b/channel.json
@@ -2,6 +2,9 @@
   // Comment plugin
   "https://raw.githubusercontent.com/micro-editor/comment-plugin/master/repo.json",
 
+  // EditorConfig plugin
+  "https://raw.githubusercontent.com/10sr/editorconfig-micro/master/repo.json",
+
   // Fish plugin
   "https://raw.githubusercontent.com/onodera-punpun/micro-fish-plugin/master/repo.json",
 


### PR DESCRIPTION
A Plugin to support [EditorConfig](http://editorconfig.org) files.

Repository: https://github.com/10sr/editorconfig-micro