### PR TITLE
Gotham colorscheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@ This repository contains the 'channel.json' file which lists all official micro 
 
 ## Plugins
 
-| Plugin         | Description                                           | Link                                                |
-| -------------- | ----------------------------------------------------- | --------------------------------------------------- |
-| `comment`      | Plugin to auto comment or uncomment lines             | https://github.com/micro-editor/comment-plugin      |
-| `snippets`     | Provides snippets functionality                       | https://github.com/boombuler/microsnippets          |
-| `go`           | Provides `gofmt` and `goimports` support for Go files | https://github.com/micro-editor/go-plugin           |
-| `fish`         | Provides `fishfmt` support for Fish files             | https://github.com/onodera-punpun/micro-fish-plugin |
-| `wc`           | Plugin to count words/characters                      | https://github.com/adamnpeace/micro-wc-plugin       |
-| `fzf`          | Provides `fzf` support for opening files              | https://github.com/samdmarshall/micro-fzf-plugin    |
-| `pony`         | Provides auto-indentation for Pony files              | https://github.com/Theodus/micro-pony-plugin        |
-| `editorconfig` | EditorConfig Support for micro                        | https://github.com/10sr/editorconfig-micro          |
-| `crystal`      | Provides various `crystal` tools for crystal files    | https://github.com/ColinRioux/micro-crystal         |
+| Plugin          | Description                                             | Link                                                   |
+| --------------- | ------------------------------------------------------- | ------------------------------------------------------ |
+| `comment`       | Plugin to auto comment or uncomment lines               | https://github.com/micro-editor/comment-plugin         |
+| `snippets`      | Provides snippets functionality                         | https://github.com/boombuler/microsnippets             |
+| `go`            | Provides `gofmt` and `goimports` support for Go files   | https://github.com/micro-editor/go-plugin              |
+| `fish`          | Provides `fishfmt` support for Fish files               | https://github.com/onodera-punpun/micro-fish-plugin    |
+| `wc`            | Plugin to count words/characters                        | https://github.com/adamnpeace/micro-wc-plugin          |
+| `fzf`           | Provides `fzf` support for opening files                | https://github.com/samdmarshall/micro-fzf-plugin       |
+| `pony`          | Provides auto-indentation for Pony files                | https://github.com/Theodus/micro-pony-plugin           |
+| `editorconfig`  | EditorConfig Support for micro                          | https://github.com/10sr/editorconfig-micro             |
+| `crystal`       | Provides various `crystal` tools for crystal files      | https://github.com/ColinRioux/micro-crystal            |
 | `gotham-colors` | A colorscheme for code that never sleeps in Gotham City | https://github.com/november-eleven/micro-gotham-colors |
 
 ## Adding your own plugin

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `pony`         | Provides auto-indentation for Pony files              | https://github.com/Theodus/micro-pony-plugin        |
 | `editorconfig` | EditorConfig Support for micro                        | https://github.com/10sr/editorconfig-micro          |
 | `crystal`      | Provides various `crystal` tools for crystal files    | https://github.com/ColinRioux/micro-crystal         |
+| `gotham-colors` | A colorscheme for code that never sleeps in Gotham City | https://github.com/november-eleven/micro-gotham-colors |
 
 ## Adding your own plugin
 

--- a/channel.json
+++ b/channel.json
@@ -19,10 +19,13 @@
 
   // wc plugin
   "https://raw.githubusercontent.com/adamnpeace/micro-wc-plugin/master/repo.json",
-  
+
   // Pony plugin
   "https://raw.githubusercontent.com/Theodus/micro-pony-plugin/master/repo.json",
 
   // Crystal plugin
-  "https://raw.githubusercontent.com/ColinRioux/micro-crystal/master/repo.json"
+  "https://raw.githubusercontent.com/ColinRioux/micro-crystal/master/repo.json",
+
+  // Gotham colorscheme
+  "https://raw.githubusercontent.com/november-eleven/micro-gotham-colors/master/repo.json"
 ]


### PR DESCRIPTION
This colorscheme is a portage of [vim-gotham](https://github.com/whatyouhide/vim-gotham) for micro.

Gotham is a **very dark** colorscheme, which look like this: 

![gotham](https://cloud.githubusercontent.com/assets/707992/21013883/e82689b6-bd5b-11e6-9ba3-a28bfcc3a6b9.png)