### PR TITLE
Revert 81999d3: remove filemanager plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `monokai-dark`  | A dark monokai colorscheme                              | https://github.com/Theodus/micro-monokai-dark           |
 | `scratch`       | Plugin to create scratch buffers                        | https://github.com/samdmarshall/micro-scratch-plugin    |
 | `manipulator`   | Extend text manipulation abilities                      | https://github.com/NicolaiSoeborg/manipulator-plugin    |
+| `filemanager`   | A file manager!                                         | https://github.com/NicolaiSoeborg/filemanager-plugin    |
 | `rubocop`       | Rubocop autoformatting                                  | https://github.com/computerers/micro-rubocop            |
 | `vcs`           | Mark changed lines in Git or Mercurial repositories     | https://bitbucket.org/dermetfan/micro-vcs               |
 

--- a/channel.json
+++ b/channel.json
@@ -41,6 +41,9 @@
   // Manipulator plugin
   "https://raw.githubusercontent.com/NicolaiSoeborg/manipulator-plugin/master/repo.json",
 
+  // Filemanager plugin
+  "https://raw.githubusercontent.com/NicolaiSoeborg/filemanager-plugin/master/repo.json",
+  
   // Rubocop plugin
   "https://raw.githubusercontent.com/computerers/micro-rubocop/master/repo.json",
 


### PR DESCRIPTION
Hey

As of v2 the plugin it shouldn't have any bugs and hopefully ready to be included again.

Thanks!