### PR TITLE
Add fzy Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `fish`          | Provides `fishfmt` support for Fish files               | https://github.com/onodera-punpun/micro-fish-plugin     |
 | `wc`            | Plugin to count words/characters                        | https://github.com/adamnpeace/micro-wc-plugin           |
 | `fzf`           | Provides `fzf` support for opening files                | https://github.com/samdmarshall/micro-fzf-plugin        |
+| `fzy`           | Adds support for `fzy` fuzzy searching                  | https://github.com/chrishalebarnes/micro-fzy-plugin     |
 | `pony`          | Provides auto-indentation for Pony files                | https://github.com/Theodus/micro-pony-plugin            |
 | `editorconfig`  | EditorConfig Support for micro                          | https://github.com/10sr/editorconfig-micro              |
 | `crystal`       | Provides various `crystal` tools for crystal files      | https://github.com/ColinRioux/micro-crystal             |

--- a/channel.json
+++ b/channel.json
@@ -11,6 +11,9 @@
   // fzf plugin
   "https://raw.githubusercontent.com/samdmarshall/micro-fzf-plugin/master/repo.json",
 
+  // fzy plugin
+  "https://raw.githubusercontent.com/chrishalebarnes/micro-fzy-plugin/master/repo.json",
+
   // Go plugin
   "https://raw.githubusercontent.com/micro-editor/go-plugin/master/repo.json",
 
@@ -43,7 +46,7 @@
 
   // Filemanager plugin
   "https://raw.githubusercontent.com/NicolaiSoeborg/filemanager-plugin/master/repo.json",
-  
+
   // Rubocop plugin
   "https://raw.githubusercontent.com/computerers/micro-rubocop/master/repo.json",
 


### PR DESCRIPTION
Add [fzy](https://github.com/jhawthorn/fzy) plugin to channel.

This is very similar to `fzf` but for `fzy` and can also find files tracked in git