### PR TITLE
change url for snippets plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | Plugin          | Description                                             | Link                                                    |
 | --------------- | ------------------------------------------------------- | ------------------------------------------------------- |
 | `comment`       | Plugin to auto comment or uncomment lines               | https://github.com/micro-editor/comment-plugin          |
-| `snippets`      | Provides snippets functionality                         | https://github.com/boombuler/microsnippets              |
+| `snippets`      | Provides snippets functionality                         | https://github.com/tommyshem/micro-snippets-plugin             |
 | `go`            | Provides `gofmt` and `goimports` support for Go files   | https://github.com/micro-editor/go-plugin               |
 | `fish`          | Provides `fishfmt` support for Fish files               | https://github.com/onodera-punpun/micro-fish-plugin     |
 | `wc`            | Plugin to count words/characters                        | https://github.com/adamnpeace/micro-wc-plugin           |

--- a/channel.json
+++ b/channel.json
@@ -15,7 +15,7 @@
   "https://raw.githubusercontent.com/micro-editor/go-plugin/master/repo.json",
 
   // Snippets plugin
-  "https://raw.githubusercontent.com/boombuler/microsnippets/master/repo.json",
+   "https://raw.githubusercontent.com/tommyshem/micro-snippets-plugin/master/repo.json",
 
   // wc plugin
   "https://raw.githubusercontent.com/adamnpeace/micro-wc-plugin/master/repo.json",


### PR DESCRIPTION
Change url for the snippets plugin as orignal coder is passing the project on.
See https://github.com/boombuler/microsnippets/pull/9 for commets.
