### PR TITLE
Remove Rubocop plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `scratch`       | Plugin to create scratch buffers                        | https://github.com/samdmarshall/micro-scratch-plugin    |
 | `manipulator`   | Extend text manipulation abilities                      | https://github.com/NicolaiSoeborg/manipulator-plugin    |
 | `filemanager`   | A file manager!                                         | https://github.com/NicolaiSoeborg/filemanager-plugin    |
-| `rubocop`       | Rubocop autoformatting                                  | https://github.com/computerers/micro-rubocop            |
 | `vcs`           | Mark changed lines in Git or Mercurial repositories     | https://bitbucket.org/dermetfan/micro-vcs               |
 | `fmt`           | A multi-language formatting plugin                      | https://github.com/sum01/fmt-micro                      |
 

--- a/channel.json
+++ b/channel.json
@@ -43,9 +43,6 @@
 
   // Filemanager plugin
   "https://raw.githubusercontent.com/NicolaiSoeborg/filemanager-plugin/master/repo.json",
-  
-  // Rubocop plugin
-  "https://raw.githubusercontent.com/computerers/micro-rubocop/master/repo.json",
 
   // VCS plugin
   "https://bitbucket.org/dermetfan/micro-vcs/raw/default/repo.json",


### PR DESCRIPTION
The Rubocop plugin doesn't point to anywhere, which makes micro run into an error when trying to update or install plugins.
I just removed it.
Fixes #36 