### PR TITLE
chore: restore upstream master repo.json for editorconfig

### DIFF
--- a/channel.json
+++ b/channel.json
@@ -3,7 +3,7 @@
   "https://raw.githubusercontent.com/micro-editor/comment-plugin/master/repo.json",
 
   // EditorConfig plugin
-  "https://raw.githubusercontent.com/micro-editor/updated-plugins/master/editorconfig-micro/repo.json",
+  "https://raw.githubusercontent.com/10sr/editorconfig-micro/master/repo.json",
 
   // Fish plugin
   "https://raw.githubusercontent.com/micro-editor/updated-plugins/master/micro-fish-plugin/repo.json",


### PR DESCRIPTION
Blocked until https://github.com/10sr/editorconfig-micro/pull/10 is merged.