### PR TITLE
Add jlabbrev plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `bounce`     | Plugin that implements nano-style smart home and bouncing the cursor between matching-brackets | https://github.com/deusnefum/micro-bounce | :heavy_check_mark:                       |
 | `quoter`     | Plugin that allows you to add quotes or brackets around selected text | https://github.com/deusnefum/micro-quoter | :heavy_check_mark:                       |
 | `zigfmt`        | Provides `zig fmt` integration for Zig files            | https://github.com/squeek502/micro-zigfmt                  | :heavy_check_mark:                       |
+| `jlabbrev`      | Provides backslash abbreviations from the julia prompt  | https://github.com/MasFlam/jlabbrev                        | :heavy_check_mark:                       |
 
 ## Adding your own plugin
 

--- a/channel.json
+++ b/channel.json
@@ -60,5 +60,8 @@
   "https://raw.githubusercontent.com/squeek502/micro-zigfmt/master/repo.json",
   
   // Aspell plugin
-  "https://raw.githubusercontent.com/priner/micro-aspell-plugin/master/repo.json"
+  "https://raw.githubusercontent.com/priner/micro-aspell-plugin/master/repo.json",
+  
+  // jlabbrev plugin
+  "https://raw.githubusercontent.com/MasFlam/jlabbrev/master/repo.json"
 ]


### PR DESCRIPTION
I created a plugin that provides all the abbreviations from the Julia prompt (which I believe were taken from LaTeX). When you for example type `\euler` and hit `<tab>`, then it gets replaced with `ℯ`. I didn't notice any slowdowns at micro startup as well, which is impressive, since there are 3000+ abbreviations. Every time you hit tab and the last backslash is on the same line to the left, the running complexity is basically O(*n*) where *n* is the X position of the cursor.