### PR TITLE
Add YAPF plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `zigfmt`        | Provides `zig fmt` integration for Zig files            | https://github.com/squeek502/micro-zigfmt                  | :heavy_check_mark:                       |
 | `jlabbrev`      | Provides backslash abbreviations from the julia prompt  | https://github.com/MasFlam/jlabbrev                        | :heavy_check_mark:                       |
 | `nord-colors`   | A set of dark and light colorschemes based on Nord      | https://github.com/KiranWells/micro-nord-tc-colors         | :heavy_check_mark:                       |
+| `yapf`          | Runs `yapf` in place when saving python files           | https://github.com/a11ce/micro-yapf                        | :heavy_check_mark:                       |
 
 ## Adding your own plugin
 

--- a/channel.json
+++ b/channel.json
@@ -70,4 +70,7 @@
   
   // nord-tc colorscheme
   "https://raw.githubusercontent.com/KiranWells/micro-nord-tc-colors/main/repo.json"
+
+  // yapf plugin
+  "https://raw.githubusercontent.com/a11ce/micro-yapf/master/repo.json"
 ]


### PR DESCRIPTION
This plugin runs `yapf` in place when saving python files and works on the newest versions of micro.