### PR TITLE
Update Nord Colors name again due to a bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `quoter`     | Plugin that allows you to add quotes or brackets around selected text | https://github.com/deusnefum/micro-quoter | :heavy_check_mark:                       |
 | `zigfmt`        | Provides `zig fmt` integration for Zig files            | https://github.com/squeek502/micro-zigfmt                  | :heavy_check_mark:                       |
 | `jlabbrev`      | Provides backslash abbreviations from the julia prompt  | https://github.com/MasFlam/jlabbrev                        | :heavy_check_mark:                       |
-| `nord-colors`   | A set of dark and light colorschemes based on Nord      | https://github.com/KiranWells/micro-nord-tc-colors         | :heavy_check_mark:                       |
+| `nordcolors`    | A set of dark and light colorschemes based on Nord      | https://github.com/KiranWells/micro-nord-tc-colors         | :heavy_check_mark:                       |
 
 ## Adding your own plugin
 

--- a/channel.json
+++ b/channel.json
@@ -68,6 +68,6 @@
   // wakatime plugin
   "https://raw.githubusercontent.com/wakatime/micro-wakatime/master/repo.json",
   
-  // nord-tc colorscheme
+  // nord colorschemes
   "https://raw.githubusercontent.com/KiranWells/micro-nord-tc-colors/main/repo.json"
 ]


### PR DESCRIPTION
Due to a bug/feature of Lua (or for some other reason), plugins with a dash in their name will not have their .lua files run. 

I will be posting a documentation issue on the main Micro account related to this, but here are the details for convenience:

My colorscheme plugin failed to properly install, as the colorschemes were not being included in the runtime files. After some troubleshooting, I discovered that the .lua file was not doing anything, even when it had deliberate errors. When I removed the dash from the plugin and .lua file name, the code ran normally.

I assume this is some issue with lua not supporting module names with dashes, or some other limitation. It is not a large issue, but I believe it should be mentioned in the plugin documentation. 

As a side note, I believe the other plugins with dashes will not be run either. This likely has not been an issue so far as they are included by default.