### PR TITLE
Add quickfix plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `jlabbrev`      | Provides backslash abbreviations from the julia prompt  | https://github.com/MasFlam/jlabbrev                        | :heavy_check_mark:                       |
 | `nord-colors`   | A set of dark and light colorschemes based on Nord      | https://github.com/KiranWells/micro-nord-tc-colors         | :heavy_check_mark:                       |
 | `yapf`          | Runs `yapf` in place when saving python files           | https://github.com/a11ce/micro-yapf                        | :heavy_check_mark:                       |
+| `quickfix`      | Adds a functionality similar to VIM quickfix pane       | https://github.com/serge-v/micro-quickfix                  | :heavy_check_mark:                       |
 
 
 ## Adding your own plugin

--- a/channel.json
+++ b/channel.json
@@ -72,5 +72,8 @@
   "https://raw.githubusercontent.com/KiranWells/micro-nord-tc-colors/main/repo.json",
 
   // yapf plugin
-  "https://raw.githubusercontent.com/a11ce/micro-yapf/master/repo.json"
+  "https://raw.githubusercontent.com/a11ce/micro-yapf/master/repo.json",
+
+  // quickfix plugin
+  "https://raw.githubusercontent.com/serge-v/micro-quickfix/main/repo.json"
 ]


### PR DESCRIPTION
Please consider merging the quickfix plugin. It provides functionality similar to quickfix window in VIM editor (a special mode to speedup the edit-compile-edit cycle).

fexec command executes args or current line as external command and captures the output in qfix pane.
fjump command parses qfix buffer for filename:line:col and allows jumping to the file location.
