### PR TITLE
Add detectindent plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `yapf`          | Runs `yapf` in place when saving python files           | https://github.com/a11ce/micro-yapf                        | :heavy_check_mark:                       |
 | `bookmark`      | Bookmark lines and quickly jump between saved positions | https://github.com/haqk/micro-bookmark                     | :heavy_check_mark:                       |
 | `quickfix`      | Adds a functionality similar to VIM quickfix pane       | https://github.com/serge-v/micro-quickfix                  | :heavy_check_mark:                       |
+| `detectindent`  | Automatically detect indentation settings               | https://github.com/dmaluka/micro-detectindent              | :heavy_check_mark:                       |
 
 
 ## Adding your own plugin

--- a/channel.json
+++ b/channel.json
@@ -78,5 +78,8 @@
   "https://raw.githubusercontent.com/haqk/micro-bookmark/main/repo.json",
 
   // quickfix plugin
-  "https://raw.githubusercontent.com/serge-v/micro-quickfix/main/repo.json"
+  "https://raw.githubusercontent.com/serge-v/micro-quickfix/main/repo.json",
+
+  // detectindent plugin
+  "https://raw.githubusercontent.com/dmaluka/micro-detectindent/master/repo.json"
 ]


### PR DESCRIPTION
Whenever a file is opened, the detectindent plugin tries to automatically detect its indentation style (spaces or tabs) and set the `tabstospaces` option accordingly.