### PR TITLE
Add delve plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `quickfix`      | Adds a functionality similar to VIM quickfix pane       | https://github.com/serge-v/micro-quickfix                  | :heavy_check_mark:                       |
 | `jump`      | Jump to any function, class or heading with F4. Go, Markdown, Python, C and in 40 other languages | https://github.com/terokarvinen/micro-jump   | :heavy_check_mark:      |
 | `detectindent`  | Automatically detect indentation settings               | https://github.com/dmaluka/micro-detectindent              | :heavy_check_mark:                       |
+| `delve`         | Integrates golang delve debugger                        | https://github.com/serge-v/micro-delve                     | :heavy_check_mark:                       |
 
 
 ## Adding your own plugin

--- a/channel.json
+++ b/channel.json
@@ -84,5 +84,8 @@
   "https://raw.githubusercontent.com/terokarvinen/micro-jump/main/repo.json",
 
   // detectindent plugin
-  "https://raw.githubusercontent.com/dmaluka/micro-detectindent/master/repo.json"
+  "https://raw.githubusercontent.com/dmaluka/micro-detectindent/master/repo.json",
+
+  // delve plugin
+  "https://raw.githubusercontent.com/serge-v/micro-delve/main/repo.json"
 ]


### PR DESCRIPTION
Please consider adding the delve plugin.

Plugin integrates delve golang debugger into micro editor.
Features:
- step-by-step debugging;
- execute dlv commands;
- right vsplitted pane with debugger output.
