### PR TITLE
Add mxc plugin to channel.json

### DIFF
--- a/channel.json
+++ b/channel.json
@@ -84,5 +84,8 @@
   "https://raw.githubusercontent.com/terokarvinen/micro-jump/main/repo.json",
 
   // detectindent plugin
-  "https://raw.githubusercontent.com/dmaluka/micro-detectindent/master/repo.json"
+  "https://raw.githubusercontent.com/dmaluka/micro-detectindent/master/repo.json",
+  
+  // mxc plugin
+  "https://raw.githubusercontent.com/cadnza/mxc/main/repo.json"
 ]


### PR DESCRIPTION
This is a plugin that executes the current script in the buffer. No permissions changing or other potential insecure stuff takes place; thing just executes the file (and makes writing and testing scripts faster 😎). Includes options, settings, a help file, and handy messages throughout. Checkout the repo [here](https://github.com/cadnza/mxc). Thanks!