### PR TITLE
Add splitterm plugin

### DIFF
--- a/channel.json
+++ b/channel.json
@@ -85,4 +85,7 @@
 
   // detectindent plugin
   "https://raw.githubusercontent.com/dmaluka/micro-detectindent/master/repo.json"
+  
+  //splitterm plugin
+  "https://raw.githubusercontent.com/lukhof/splitterm/main/repo.json"
 ]


### PR DESCRIPTION
Add splitterm plugin, a plugin which lets you run python/bash/perl code in a new split terminal. You can select portions of the code or run the whole file (if nothing is selected).