### PR TITLE
Add fzfinder plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `quickfix`      | Adds a functionality similar to VIM quickfix pane       | https://github.com/serge-v/micro-quickfix                  | :heavy_check_mark:                       |
 | `jump`      | Jump to any function, class or heading with F4. Go, Markdown, Python, C and in 40 other languages | https://github.com/terokarvinen/micro-jump   | :heavy_check_mark:      |
 | `detectindent`  | Automatically detect indentation settings               | https://github.com/dmaluka/micro-detectindent              | :heavy_check_mark:                       |
+| `fzfinder`  | The plugin allows you to integrate fzf to select and search for your project files | https://github.com/MuratovAS/micro-fzfinder              | :heavy_check_mark:                       |
 
 
 ## Adding your own plugin

--- a/channel.json
+++ b/channel.json
@@ -84,5 +84,8 @@
   "https://raw.githubusercontent.com/terokarvinen/micro-jump/main/repo.json",
 
   // detectindent plugin
-  "https://raw.githubusercontent.com/dmaluka/micro-detectindent/master/repo.json"
+  "https://raw.githubusercontent.com/dmaluka/micro-detectindent/master/repo.json",
+
+  // fzfinder plugin
+  "https://raw.githubusercontent.com/MuratovAS/micro-fzfinder/main/repo.json"
 ]


### PR DESCRIPTION
The plugin allows you to integrate fzf to select and search for your project files.

This plugin is an alternative implementation of `FZF`. Adds a new feature, corrects the malfunctions of an alternative version. 