### PR TITLE
Add selto plugin

### DIFF
--- a/channel.json
+++ b/channel.json
@@ -81,5 +81,5 @@
   "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-plugin-lsp.json"
 
   // selto plugin
-  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/selto.json"  
+  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-selto.json"  
 ]

--- a/channel.json
+++ b/channel.json
@@ -79,4 +79,7 @@
 
   // lsp plugin
   "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-plugin-lsp.json"
+
+  // selto plugin
+  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/selto.json"  
 ]

--- a/plugins/micro-selto.json
+++ b/plugins/micro-selto.json
@@ -2,12 +2,12 @@
   "Name": "selto",
   "Description": "Simple plugin allowing to quickly select lines",
   "Tags": ["selection", "select", "lines", "line"],
-  "Website": "https://github.com/PawelMTRK/selto-plugin",
+  "Website": "https://github.com/PawelMTRK/micro-selto-plugin",
   "Licence": "MIT",
   "Versions": [
     {
       "Version": "1.0.0",
-      "Url": "https://github.com/PawelMTRK/selto-plugin/archive/refs/tags/v1.0.0.zip",
+      "Url": "https://github.com/PawelMTRK/micro-selto-plugin/archive/refs/tags/v1.0.0.zip",
       "Require": {
         "micro": ">=2.0.0"
       }

--- a/plugins/selto.json
+++ b/plugins/selto.json
@@ -1,0 +1,16 @@
+[{
+  "Name": "selto",
+  "Description": "Simple plugin allowing to quickly select lines",
+  "Tags": ["selection", "select", "lines", "line"],
+  "Website": "https://github.com/PawelMTRK/selto-plugin",
+  "Licence": "MIT",
+  "Versions": [
+    {
+      "Version": "1.0.0",
+      "Url": "https://github.com/PawelMTRK/selto-plugin/archive/refs/tags/v1.0.0.zip",
+      "Require": {
+        "micro": ">=2.0.0"
+      }
+    }
+  ]
+}]


### PR DESCRIPTION
This is a

* [X] New plugin.
* [ ] Update to an existing plugin.

Plugin name and version: selto, v1.0.0

Plugin source code zip file: (please upload a zip file or link a zip file).
https://github.com/PawelMTRK/micro-selto-plugin/archive/refs/tags/v1.0.0.zip

<!-- In your PR, please list the zip file link as if it has been uploaded to https://github.com/micro-editor/plugin-channel/releases/tag/plugins. -->
<!-- If your plugin is approved, it will be uploaded there when merging the PR. -->

Checklist:

* [X] Plugin has a repo.json listing the `Name`, `Description`, `Website`, and `License`.
* [X] I have read the instructions at https://github.com/micro-editor/plugin-channel#adding-your-own-plugin.

---

Link to the plugin repo:  
https://github.com/PawelMTRK/micro-selto-plugin

Link to the zip file as if it has been uploaded to the repo:  
https://github.com/micro-editor/plugin-channel/releases/download/plugins/micro-selto-1.0.0.zip

---