### PR TITLE
Update micro-bookmark to v2.5.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+This is a
+
+* [ ] New plugin.
+* [ ] Update to an existing plugin.
+
+Plugin name and version: ...
+
+Plugin source code zip file: (please upload a zip file or link a zip file).
+
+<!-- In your PR, please list the zip file link as if it has been uploaded to https://github.com/micro-editor/plugin-channel/releases/tag/plugins. -->
+<!-- If your plugin is approved, it will be uploaded there when merging the PR. -->
+
+Checklist:
+
+* [ ] Plugin has a repo.json listing the `Name`, `Description`, `Website`, and `License`.
+* [ ] I have read the instructions at https://github.com/micro-editor/plugin-channel#adding-your-own-plugin.
+
+---
+
+<!-- Other comments here -->

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `go`        | Provides `gofmt` and `goimports` support for Go files | https://github.com/micro-editor/go-plugin           |
 | `fish`      | Provides `fishfmt` support for Fish files             | https://github.com/onodera-punpun/micro-fish-plugin |
 | `wc`        | Plugin to count words/characters                      | https://github.com/adamnpeace/micro-wc-plugin       |
+| `fzf`       | Provides `fzf` support for opening files              | https://github.com/samdmarshall/micro-fzf-plugin    |
 
 ## Adding your own plugin
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ This repository contains the 'channel.json' file which lists all official micro 
 
 ## Plugins
 
-<<<<<<< HEAD
 | Plugin         | Description                                           | Link                                                |
 | -------------- | ----------------------------------------------------- | --------------------------------------------------- |
 | `comment`      | Plugin to auto comment or uncomment lines             | https://github.com/micro-editor/comment-plugin      |

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `bounce`     | Plugin that implements nano-style smart home and bouncing the cursor between matching-brackets | https://github.com/deusnefum/micro-bounce | :heavy_check_mark:                       |
 | `quoter`     | Plugin that allows you to add quotes or brackets around selected text | https://github.com/deusnefum/micro-quoter | :heavy_check_mark:                       |
 | `zigfmt`        | Provides `zig fmt` integration for Zig files            | https://github.com/squeek502/micro-zigfmt                  | :heavy_check_mark:                       |
+| `jlabbrev`      | Provides backslash abbreviations from the julia prompt  | https://github.com/MasFlam/jlabbrev                        | :heavy_check_mark:                       |
 
 ## Adding your own plugin
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `vcs`           | Mark changed lines in Git or Mercurial repositories     | https://bitbucket.org/dermetfan/micro-vcs                  | :heavy_check_mark: (provided by default) |
 | `fmt`           | A multi-language formatting plugin                      | https://github.com/sum01/fmt-micro                         | :x:                                      |
 | `joinLines`     | Plugin which joins selected lines or the following with the current | https://github.com/Lisiadito/join-lines-plugin | :heavy_check_mark:                       |
+| `bounce`     | Plugin that implements nano-style smart home and bouncing the cursor between matching-brackets | https://github.com/deusnefum/micro-bounce | :heavy_check_mark:                       |
+| `quoter`     | Plugin that allows you to add quotes or brackets around selected text | https://github.com/deusnefum/micro-quoter | :heavy_check_mark:                       |
 
 ## Adding your own plugin
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Then you can open a pull request which adds the link to that file to the
 files in your PR. If you PR is accepted, I will upload those zip files to
 the `plugins` release so they will be accessible to all micro users.
 
+Please make sure to add a License to your plugin.
+
 ## Updating your plugin
 
 If you come out with a new version of your plugin, please open a PR modifying

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `gotham-colors` | A colorscheme for code that never sleeps in Gotham City | https://github.com/novln/micro-gotham-colors            |
 | `misspell`      | Plugin that corrects commonly misspelled words          | https://github.com/onodera-punpun/micro-misspell-plugin |
 | `monokai-dark`  | A dark monokai colorscheme                              | https://github.com/Theodus/micro-monokai-dark           |
+| `manipulator`   | Extend text manipulation abilities                      | https://github.com/NicolaiSoeborg/manipulator-plugin    |
 
 ## Adding your own plugin
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `quoter`     | Plugin that allows you to add quotes or brackets around selected text | https://github.com/deusnefum/micro-quoter | :heavy_check_mark:                       |
 | `zigfmt`        | Provides `zig fmt` integration for Zig files            | https://github.com/squeek502/micro-zigfmt                  | :heavy_check_mark:                       |
 | `jlabbrev`      | Provides backslash abbreviations from the julia prompt  | https://github.com/MasFlam/jlabbrev                        | :heavy_check_mark:                       |
-| `nord-tc`      | A dark colorscheme based on Nord  | https://github.com/KiranWells/micro-nord-tc-colors                        | :heavy_check_mark:                       |
+| `nord-colors`   | A set of dark and light colorschemes based on Nord      | https://github.com/KiranWells/micro-nord-tc-colors         | :heavy_check_mark:                       |
 
 ## Adding your own plugin
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `pony`          | Provides auto-indentation for Pony files                | https://github.com/Theodus/micro-pony-plugin            |
 | `editorconfig`  | EditorConfig Support for micro                          | https://github.com/10sr/editorconfig-micro              |
 | `crystal`       | Provides various `crystal` tools for crystal files      | https://github.com/ColinRioux/micro-crystal             |
-| `gotham-colors` | A colorscheme for code that never sleeps in Gotham City | https://github.com/november-eleven/micro-gotham-colors  |
+| `gotham-colors` | A colorscheme for code that never sleeps in Gotham City | https://github.com/novln/micro-gotham-colors            |
 | `misspell`      | Plugin that corrects commonly misspelled words          | https://github.com/onodera-punpun/micro-misspell-plugin |
 | `monokai-dark`  | A dark monokai colorscheme                              | https://github.com/Theodus/micro-monokai-dark           |
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `quoter`     | Plugin that allows you to add quotes or brackets around selected text | https://github.com/deusnefum/micro-quoter | :heavy_check_mark:                       |
 | `zigfmt`        | Provides `zig fmt` integration for Zig files            | https://github.com/squeek502/micro-zigfmt                  | :heavy_check_mark:                       |
 | `jlabbrev`      | Provides backslash abbreviations from the julia prompt  | https://github.com/MasFlam/jlabbrev                        | :heavy_check_mark:                       |
-| `nordcolors`    | A set of dark and light colorschemes based on Nord      | https://github.com/KiranWells/micro-nord-tc-colors         | :heavy_check_mark:                       |
+| `nord-colors`   | A set of dark and light colorschemes based on Nord      | https://github.com/KiranWells/micro-nord-tc-colors         | :heavy_check_mark:                       |
+| `yapf`          | Runs `yapf` in place when saving python files           | https://github.com/a11ce/micro-yapf                        | :heavy_check_mark:                       |
+
 
 ## Adding your own plugin
 

--- a/README.md
+++ b/README.md
@@ -4,17 +4,18 @@ This repository contains the 'channel.json' file which lists all official micro 
 
 ## Plugins
 
-| Plugin         | Description                                           | Link                                                |
-| -------------- | ----------------------------------------------------- | --------------------------------------------------- |
-| `comment`      | Plugin to auto comment or uncomment lines             | https://github.com/micro-editor/comment-plugin      |
-| `snippets`     | Provides snippets functionality                       | https://github.com/boombuler/microsnippets          |
-| `go`           | Provides `gofmt` and `goimports` support for Go files | https://github.com/micro-editor/go-plugin           |
-| `fish`         | Provides `fishfmt` support for Fish files             | https://github.com/onodera-punpun/micro-fish-plugin |
-| `wc`           | Plugin to count words/characters                      | https://github.com/adamnpeace/micro-wc-plugin       |
-| `fzf`          | Provides `fzf` support for opening files              | https://github.com/samdmarshall/micro-fzf-plugin    |
-| `pony`         | Provides auto-indentation for Pony files              | https://github.com/Theodus/micro-pony-plugin        |
-| `editorconfig` | EditorConfig Support for micro                        | https://github.com/10sr/editorconfig-micro          |
-| `crystal`      | Provides various `crystal` tools for crystal files    | https://github.com/ColinRioux/micro-crystal         |
+| Plugin         | Description                                           | Link                                                    |
+| -------------- | ----------------------------------------------------- | ------------------------------------------------------- |
+| `comment`      | Plugin to auto comment or uncomment lines             | https://github.com/micro-editor/comment-plugin          |
+| `snippets`     | Provides snippets functionality                       | https://github.com/boombuler/microsnippets              |
+| `go`           | Provides `gofmt` and `goimports` support for Go files | https://github.com/micro-editor/go-plugin               |
+| `fish`         | Provides `fishfmt` support for Fish files             | https://github.com/onodera-punpun/micro-fish-plugin     |
+| `wc`           | Plugin to count words/characters                      | https://github.com/adamnpeace/micro-wc-plugin           |
+| `fzf`          | Provides `fzf` support for opening files              | https://github.com/samdmarshall/micro-fzf-plugin        |
+| `pony`         | Provides auto-indentation for Pony files              | https://github.com/Theodus/micro-pony-plugin            |
+| `editorconfig` | EditorConfig Support for micro                        | https://github.com/10sr/editorconfig-micro              |
+| `crystal`      | Provides various `crystal` tools for crystal files    | https://github.com/ColinRioux/micro-crystal             |
+| `misspell`     | Plugin that corrects commonly misspelled words        | https://github.com/onodera-punpun/micro-misspell-plugin |
 
 ## Adding your own plugin
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | Plugin          | Description                                             | Link                                                    |
 | --------------- | ------------------------------------------------------- | ------------------------------------------------------- |
 | `comment`       | Plugin to auto comment or uncomment lines               | https://github.com/micro-editor/comment-plugin          |
-| `snippets`      | Provides snippets functionality                         | https://github.com/boombuler/microsnippets              |
+| `snippets`      | Provides snippets functionality                         | https://github.com/tommyshem/micro-snippets-plugin             |
 | `go`            | Provides `gofmt` and `goimports` support for Go files   | https://github.com/micro-editor/go-plugin               |
 | `fish`          | Provides `fishfmt` support for Fish files               | https://github.com/onodera-punpun/micro-fish-plugin     |
 | `wc`            | Plugin to count words/characters                        | https://github.com/adamnpeace/micro-wc-plugin           |

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `monokai-dark`  | A dark monokai colorscheme                              | https://github.com/Theodus/micro-monokai-dark           |
 | `scratch`       | Plugin to create scratch buffers                        | https://github.com/samdmarshall/micro-scratch-plugin    |
 | `manipulator`   | Extend text manipulation abilities                      | https://github.com/NicolaiSoeborg/manipulator-plugin    |
-| `filemanager`   | A file manager!                                         | https://github.com/NicolaiSoeborg/filemanager-plugin    |
 | `rubocop`       | Rubocop autoformatting                                  | https://github.com/computerers/micro-rubocop    |
 
 ## Adding your own plugin

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `fish`      | Provides `fishfmt` support for Fish files             | https://github.com/onodera-punpun/micro-fish-plugin |
 | `wc`        | Plugin to count words/characters                      | https://github.com/adamnpeace/micro-wc-plugin       |
 | `fzf`       | Provides `fzf` support for opening files              | https://github.com/samdmarshall/micro-fzf-plugin    |
+| `pony`      | Provides auto-indentation for Pony files              | https://github.com/Theodus/micro-pony-plugin        |
 
 ## Adding your own plugin
 

--- a/README.md
+++ b/README.md
@@ -18,18 +18,16 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `gotham-colors` | A colorscheme for code that never sleeps in Gotham City | https://github.com/novln/micro-gotham-colors               | :heavy_check_mark: (provided by default) |
 | `misspell`      | Plugin that corrects commonly misspelled words          | https://github.com/onodera-punpun/micro-misspell-plugin    | :heavy_check_mark:                       |
 | `monokai-dark`  | A dark monokai colorscheme                              | https://github.com/Theodus/micro-monokai-dark              | :heavy_check_mark: (provided by default) |
-| `scratch`       | Plugin to create scratch buffers                        | https://github.com/samdmarshall/micro-scratch-plugin       | :x:                                      |
 | `manipulator`   | Extend text manipulation abilities                      | https://github.com/NicolaiSoeborg/manipulator-plugin       | :heavy_check_mark:                       |
 | `filemanager`   | A file manager!                                         | https://github.com/NicolaiSoeborg/filemanager-plugin       | :heavy_check_mark:                       |
 | `vcs`           | Mark changed lines in Git or Mercurial repositories     | https://bitbucket.org/dermetfan/micro-vcs                  | :heavy_check_mark: (provided by default) |
-| `fmt`           | A multi-language formatting plugin                      | https://github.com/sum01/fmt-micro                         | :x:                                      |
 | `joinLines`     | Plugin which joins selected lines or the following with the current | https://github.com/Lisiadito/join-lines-plugin | :heavy_check_mark:                       |
 | `bounce`     | Plugin that implements nano-style smart home and bouncing the cursor between matching-brackets | https://github.com/deusnefum/micro-bounce | :heavy_check_mark:                       |
 | `quoter`     | Plugin that allows you to add quotes or brackets around selected text | https://github.com/deusnefum/micro-quoter | :heavy_check_mark:                       |
 | `zigfmt`        | Provides `zig fmt` integration for Zig files            | https://github.com/squeek502/micro-zigfmt                  | :heavy_check_mark:                       |
 | `jlabbrev`      | Provides backslash abbreviations from the julia prompt  | https://github.com/MasFlam/jlabbrev                        | :heavy_check_mark:                       |
 | `nord-colors`   | A set of dark and light colorschemes based on Nord      | https://github.com/KiranWells/micro-nord-tc-colors         | :heavy_check_mark:                       |
-| `yapf`          | Runs `yapf` in place when saving python files           | https://github.com/a11ce/micro-yapf                        | :heavy_check_mark:                       |
+| `autofmt`          | Runs `yapf` (or other autoformatters) in place when saving files           | https://github.com/a11ce/micro-yapf                        | :heavy_check_mark:                       |
 | `bookmark`      | Bookmark lines and quickly jump between saved positions | https://github.com/haqk/micro-bookmark                     | :heavy_check_mark:                       |
 | `quickfix`      | Adds a functionality similar to VIM quickfix pane       | https://github.com/serge-v/micro-quickfix                  | :heavy_check_mark:                       |
 | `jump`      | Jump to any function, class or heading with F4. Go, Markdown, Python, C and in 40 other languages | https://github.com/terokarvinen/micro-jump   | :heavy_check_mark:      |
@@ -39,6 +37,24 @@ This repository contains the 'channel.json' file which lists all official micro 
 
 ## Adding your own plugin
 
-To add your own plugin, create a `repo.json` file containing all the metadata information for your plugin. See the Go plugin [repo.json](https://github.com/micro-editor/go-plugin/blob/master/repo.json) file as an example.
+To add your own plugin, create a `repo.json` file containing all the metadata
+information for your plugin. See the Go plugin
+[repo.json](https://github.com/micro-editor/go-plugin/blob/master/repo.json)
+file as an example.
 
-Then you can open a pull request which adds the link to that file to the `channel.json` file in this repo.
+Then create a `plugins/plugin.json` file in this repository that specifies the
+zip file to download for the versions of micro you support. Point the zip files
+to the `plugins` release, like the other plugins, even though the zip will not
+exist at the time when you create the JSON file.
+
+Then you can open a pull request which adds the link to that file to the
+`channel.json` file in this repo, and upload or provide a link to the zip
+files in your PR. If you PR is accepted, I will upload those zip files to
+the `plugins` release so they will be accessible to all micro users.
+
+## Updating your plugin
+
+If you come out with a new version of your plugin, please open a PR modifying
+the `plugins/plugin.json` with your new version. Upload or provide a link to
+the zip file. When the update is approved I will upload this file to the
+`plugins` release.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `misspell`      | Plugin that corrects commonly misspelled words          | https://github.com/onodera-punpun/micro-misspell-plugin |
 | `monokai-dark`  | A dark monokai colorscheme                              | https://github.com/Theodus/micro-monokai-dark           |
 | `manipulator`   | Extend text manipulation abilities                      | https://github.com/NicolaiSoeborg/manipulator-plugin    |
+| `filemanager`   | A file manager!                                         | https://github.com/NicolaiSoeborg/filemanager-plugin    |
 
 ## Adding your own plugin
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `yapf`          | Runs `yapf` in place when saving python files           | https://github.com/a11ce/micro-yapf                        | :heavy_check_mark:                       |
 | `bookmark`      | Bookmark lines and quickly jump between saved positions | https://github.com/haqk/micro-bookmark                     | :heavy_check_mark:                       |
 | `quickfix`      | Adds a functionality similar to VIM quickfix pane       | https://github.com/serge-v/micro-quickfix                  | :heavy_check_mark:                       |
+| `jump`      | Jump to any function, class or heading with F4. Go, Markdown, Python, C and in 40 other languages | https://github.com/terokarvinen/micro-jump   | :heavy_check_mark:      |
 | `detectindent`  | Automatically detect indentation settings               | https://github.com/dmaluka/micro-detectindent              | :heavy_check_mark:                       |
 
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `monokai-dark`  | A dark monokai colorscheme                              | https://github.com/Theodus/micro-monokai-dark           |
 | `scratch`       | Plugin to create scratch buffers                        | https://github.com/samdmarshall/micro-scratch-plugin    |
 | `manipulator`   | Extend text manipulation abilities                      | https://github.com/NicolaiSoeborg/manipulator-plugin    |
+| `filemanager`   | A file manager!                                         | https://github.com/NicolaiSoeborg/filemanager-plugin    |
 | `rubocop`       | Rubocop autoformatting                                  | https://github.com/computerers/micro-rubocop            |
 | `vcs`           | Mark changed lines in Git or Mercurial repositories     | https://bitbucket.org/dermetfan/micro-vcs               |
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `editorconfig`  | EditorConfig Support for micro                          | https://github.com/10sr/editorconfig-micro             |
 | `crystal`       | Provides various `crystal` tools for crystal files      | https://github.com/ColinRioux/micro-crystal            |
 | `gotham-colors` | A colorscheme for code that never sleeps in Gotham City | https://github.com/november-eleven/micro-gotham-colors |
+| `misspell`      | Plugin that corrects commonly misspelled words          | https://github.com/onodera-punpun/micro-misspell-plugin |
 | `monokai-dark`  | A dark monokai colorscheme                              | https://github.com/Theodus/micro-monokai-dark          |
 
 ## Adding your own plugin

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | Plugin          | Description                                             | Link                                                       | 2.0 Support                              |
 | --------------- | ------------------------------------------------------- | -------------------------------------------------------    | ---------------------------------------- |
 | `comment`       | Plugin to auto comment or uncomment lines               | https://github.com/micro-editor/comment-plugin             | :heavy_check_mark: (provided by default) |
-| `snippets`      | Provides snippets functionality                         | https://github.com/tommyshem/micro-snippets-plugin         | :heavy_check_mark:                       |
+| `snippets`      | Provides snippets functionality                         | https://github.com/micro-editor/updated-plugins/tree/master/micro-snippets-plugin         | :heavy_check_mark:                       |
 | `go`            | Provides `gofmt` and `goimports` support for Go files   | https://github.com/micro-editor/go-plugin                  | :heavy_check_mark:                       |
 | `fish`          | Provides `fishfmt` support for Fish files               | https://github.com/onodera-punpun/micro-fish-plugin        | :heavy_check_mark:                       |
 | `wc`            | Plugin to count words/characters                        | https://github.com/adamnpeace/micro-wc-plugin              | :heavy_check_mark:                       |

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `gotham-colors` | A colorscheme for code that never sleeps in Gotham City | https://github.com/november-eleven/micro-gotham-colors  |
 | `misspell`      | Plugin that corrects commonly misspelled words          | https://github.com/onodera-punpun/micro-misspell-plugin |
 | `monokai-dark`  | A dark monokai colorscheme                              | https://github.com/Theodus/micro-monokai-dark           |
+| `scratch`       | Plugin to create scratch buffers                        | https://github.com/samdmarshall/micro-scratch-plugin    |
 
 ## Adding your own plugin
 

--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@ This repository contains the 'channel.json' file which lists all official micro 
 
 ## Plugins
 
-| Plugin         | Description                                           | Link                                                |
-| -------------- | ----------------------------------------------------- | --------------------------------------------------- |
-| `comment`      | Plugin to auto comment or uncomment lines             | https://github.com/micro-editor/comment-plugin      |
-| `snippets`     | Provides snippets functionality                       | https://github.com/boombuler/microsnippets          |
-| `go`           | Provides `gofmt` and `goimports` support for Go files | https://github.com/micro-editor/go-plugin           |
-| `fish`         | Provides `fishfmt` support for Fish files             | https://github.com/onodera-punpun/micro-fish-plugin |
-| `wc`           | Plugin to count words/characters                      | https://github.com/adamnpeace/micro-wc-plugin       |
-| `fzf`          | Provides `fzf` support for opening files              | https://github.com/samdmarshall/micro-fzf-plugin    |
-| `pony`         | Provides auto-indentation for Pony files              | https://github.com/Theodus/micro-pony-plugin        |
-| `editorconfig` | EditorConfig Support for micro                        | https://github.com/10sr/editorconfig-micro          |
-| `crystal`      | Provides various `crystal` tools for crystal files    | https://github.com/ColinRioux/micro-crystal         |
+| Plugin          | Description                                             | Link                                                   |
+| --------------- | ------------------------------------------------------- | ------------------------------------------------------ |
+| `comment`       | Plugin to auto comment or uncomment lines               | https://github.com/micro-editor/comment-plugin         |
+| `snippets`      | Provides snippets functionality                         | https://github.com/boombuler/microsnippets             |
+| `go`            | Provides `gofmt` and `goimports` support for Go files   | https://github.com/micro-editor/go-plugin              |
+| `fish`          | Provides `fishfmt` support for Fish files               | https://github.com/onodera-punpun/micro-fish-plugin    |
+| `wc`            | Plugin to count words/characters                        | https://github.com/adamnpeace/micro-wc-plugin          |
+| `fzf`           | Provides `fzf` support for opening files                | https://github.com/samdmarshall/micro-fzf-plugin       |
+| `pony`          | Provides auto-indentation for Pony files                | https://github.com/Theodus/micro-pony-plugin           |
+| `editorconfig`  | EditorConfig Support for micro                          | https://github.com/10sr/editorconfig-micro             |
+| `crystal`       | Provides various `crystal` tools for crystal files      | https://github.com/ColinRioux/micro-crystal            |
 | `gotham-colors` | A colorscheme for code that never sleeps in Gotham City | https://github.com/november-eleven/micro-gotham-colors |
 
 ## Adding your own plugin

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `quickfix`      | Adds a functionality similar to VIM quickfix pane       | https://github.com/serge-v/micro-quickfix                  | :heavy_check_mark:                       |
 | `jump`      | Jump to any function, class or heading with F4. Go, Markdown, Python, C and in 40 other languages | https://github.com/terokarvinen/micro-jump   | :heavy_check_mark:      |
 | `detectindent`  | Automatically detect indentation settings               | https://github.com/dmaluka/micro-detectindent              | :heavy_check_mark:                       |
+| `lsp`           | An basic LSP client implementation                      | https://github.com/AndCake/micro-plugin-lsp                | :heavy_check_mark:                       |
 
 
 ## Adding your own plugin

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `pony`         | Provides auto-indentation for Pony files              | https://github.com/Theodus/micro-pony-plugin        |
 | `editorconfig` | EditorConfig Support for micro                        | https://github.com/10sr/editorconfig-micro          |
 | `crystal`      | Provides various `crystal` tools for crystal files    | https://github.com/ColinRioux/micro-crystal         |
+| `gotham-colors` | A colorscheme for code that never sleeps in Gotham City | https://github.com/november-eleven/micro-gotham-colors |
 
 ## Adding your own plugin
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `scratch`       | Plugin to create scratch buffers                        | https://github.com/samdmarshall/micro-scratch-plugin    |
 | `manipulator`   | Extend text manipulation abilities                      | https://github.com/NicolaiSoeborg/manipulator-plugin    |
 | `filemanager`   | A file manager!                                         | https://github.com/NicolaiSoeborg/filemanager-plugin    |
-
+| `rubocop`       | Rubocop autoformatting                                  | https://github.com/computerers/micro-rubocop    |
 
 ## Adding your own plugin
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `jlabbrev`      | Provides backslash abbreviations from the julia prompt  | https://github.com/MasFlam/jlabbrev                        | :heavy_check_mark:                       |
 | `nord-colors`   | A set of dark and light colorschemes based on Nord      | https://github.com/KiranWells/micro-nord-tc-colors         | :heavy_check_mark:                       |
 | `yapf`          | Runs `yapf` in place when saving python files           | https://github.com/a11ce/micro-yapf                        | :heavy_check_mark:                       |
+| `bookmark`      | Bookmark lines and quickly jump between saved positions | https://github.com/haqk/micro-bookmark                     | :heavy_check_mark:                       |
 
 
 ## Adding your own plugin

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `fzf`          | Provides `fzf` support for opening files              | https://github.com/samdmarshall/micro-fzf-plugin    |
 | `pony`         | Provides auto-indentation for Pony files              | https://github.com/Theodus/micro-pony-plugin        |
 | `editorconfig` | EditorConfig Support for micro                        | https://github.com/10sr/editorconfig-micro          |
+| `crystal`      | Provides various `crystal` tools for crystal files    | https://github.com/ColinRioux/micro-crystal         |
 
 ## Adding your own plugin
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | Plugin          | Description                                             | Link                                                    |
 | --------------- | ------------------------------------------------------- | ------------------------------------------------------- |
 | `comment`       | Plugin to auto comment or uncomment lines               | https://github.com/micro-editor/comment-plugin          |
-| `snippets`      | Provides snippets functionality                         | https://github.com/tommyshem/micro-snippets-plugin             |
+| `snippets`      | Provides snippets functionality                         | https://github.com/tommyshem/micro-snippets-plugin      |
 | `go`            | Provides `gofmt` and `goimports` support for Go files   | https://github.com/micro-editor/go-plugin               |
 | `fish`          | Provides `fishfmt` support for Fish files               | https://github.com/onodera-punpun/micro-fish-plugin     |
 | `wc`            | Plugin to count words/characters                        | https://github.com/adamnpeace/micro-wc-plugin           |
@@ -23,6 +23,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `filemanager`   | A file manager!                                         | https://github.com/NicolaiSoeborg/filemanager-plugin    |
 | `vcs`           | Mark changed lines in Git or Mercurial repositories     | https://bitbucket.org/dermetfan/micro-vcs               |
 | `fmt`           | A multi-language formatting plugin                      | https://github.com/sum01/fmt-micro                      |
+| `joinLines`     | Plugin which joins selected lines or the following with the current | https://github.com/Lisiadito/join-lines-plugin |
 
 ## Adding your own plugin
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `yapf`          | Runs `yapf` in place when saving python files           | https://github.com/a11ce/micro-yapf                        | :heavy_check_mark:                       |
 | `bookmark`      | Bookmark lines and quickly jump between saved positions | https://github.com/haqk/micro-bookmark                     | :heavy_check_mark:                       |
 | `quickfix`      | Adds a functionality similar to VIM quickfix pane       | https://github.com/serge-v/micro-quickfix                  | :heavy_check_mark:                       |
+| `detectindent`  | Automatically detect indentation settings               | https://github.com/dmaluka/micro-detectindent              | :heavy_check_mark:                       |
 
 
 ## Adding your own plugin

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `editorconfig`  | EditorConfig Support for micro                          | https://github.com/10sr/editorconfig-micro             |
 | `crystal`       | Provides various `crystal` tools for crystal files      | https://github.com/ColinRioux/micro-crystal            |
 | `gotham-colors` | A colorscheme for code that never sleeps in Gotham City | https://github.com/november-eleven/micro-gotham-colors |
+| `monokai-dark`  | A dark monokai colorscheme                              | https://github.com/Theodus/micro-monokai-dark          |
 
 ## Adding your own plugin
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `scratch`       | Plugin to create scratch buffers                        | https://github.com/samdmarshall/micro-scratch-plugin    |
 | `manipulator`   | Extend text manipulation abilities                      | https://github.com/NicolaiSoeborg/manipulator-plugin    |
 | `filemanager`   | A file manager!                                         | https://github.com/NicolaiSoeborg/filemanager-plugin    |
-| `rubocop`       | Rubocop autoformatting                                  | https://github.com/computerers/micro-rubocop            |
 | `vcs`           | Mark changed lines in Git or Mercurial repositories     | https://bitbucket.org/dermetfan/micro-vcs               |
 | `fmt`           | A multi-language formatting plugin                      | https://github.com/sum01/fmt-micro                      |
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `monokai-dark`  | A dark monokai colorscheme                              | https://github.com/Theodus/micro-monokai-dark           |
 | `scratch`       | Plugin to create scratch buffers                        | https://github.com/samdmarshall/micro-scratch-plugin    |
 | `manipulator`   | Extend text manipulation abilities                      | https://github.com/NicolaiSoeborg/manipulator-plugin    |
-| `rubocop`       | Rubocop autoformatting                                  | https://github.com/computerers/micro-rubocop    |
+| `rubocop`       | Rubocop autoformatting                                  | https://github.com/computerers/micro-rubocop            |
+| `vcs`           | Mark changed lines in Git or Mercurial repositories     | https://bitbucket.org/dermetfan/micro-vcs               |
 
 ## Adding your own plugin
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `jlabbrev`      | Provides backslash abbreviations from the julia prompt  | https://github.com/MasFlam/jlabbrev                        | :heavy_check_mark:                       |
 | `nord-colors`   | A set of dark and light colorschemes based on Nord      | https://github.com/KiranWells/micro-nord-tc-colors         | :heavy_check_mark:                       |
 | `yapf`          | Runs `yapf` in place when saving python files           | https://github.com/a11ce/micro-yapf                        | :heavy_check_mark:                       |
+| `quickfix`      | Adds a functionality similar to VIM quickfix pane       | https://github.com/serge-v/micro-quickfix                  | :heavy_check_mark:                       |
 
 
 ## Adding your own plugin

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `quoter`     | Plugin that allows you to add quotes or brackets around selected text | https://github.com/deusnefum/micro-quoter | :heavy_check_mark:                       |
 | `zigfmt`        | Provides `zig fmt` integration for Zig files            | https://github.com/squeek502/micro-zigfmt                  | :heavy_check_mark:                       |
 | `jlabbrev`      | Provides backslash abbreviations from the julia prompt  | https://github.com/MasFlam/jlabbrev                        | :heavy_check_mark:                       |
-| `nord-colors`   | A set of dark and light colorschemes based on Nord      | https://github.com/KiranWells/micro-nord-tc-colors         | :heavy_check_mark:                       |
+| `nordcolors`    | A set of dark and light colorschemes based on Nord      | https://github.com/KiranWells/micro-nord-tc-colors         | :heavy_check_mark:                       |
 
 ## Adding your own plugin
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `filemanager`   | A file manager!                                         | https://github.com/NicolaiSoeborg/filemanager-plugin    |
 | `rubocop`       | Rubocop autoformatting                                  | https://github.com/computerers/micro-rubocop            |
 | `vcs`           | Mark changed lines in Git or Mercurial repositories     | https://bitbucket.org/dermetfan/micro-vcs               |
+| `fmt`           | A multi-language formatting plugin                      | https://github.com/sum01/fmt-micro                      |
 
 ## Adding your own plugin
 

--- a/README.md
+++ b/README.md
@@ -4,26 +4,26 @@ This repository contains the 'channel.json' file which lists all official micro 
 
 ## Plugins
 
-| Plugin          | Description                                             | Link                                                    |
-| --------------- | ------------------------------------------------------- | ------------------------------------------------------- |
-| `comment`       | Plugin to auto comment or uncomment lines               | https://github.com/micro-editor/comment-plugin          |
-| `snippets`      | Provides snippets functionality                         | https://github.com/tommyshem/micro-snippets-plugin      |
-| `go`            | Provides `gofmt` and `goimports` support for Go files   | https://github.com/micro-editor/go-plugin               |
-| `fish`          | Provides `fishfmt` support for Fish files               | https://github.com/onodera-punpun/micro-fish-plugin     |
-| `wc`            | Plugin to count words/characters                        | https://github.com/adamnpeace/micro-wc-plugin           |
-| `fzf`           | Provides `fzf` support for opening files                | https://github.com/samdmarshall/micro-fzf-plugin        |
-| `pony`          | Provides auto-indentation for Pony files                | https://github.com/Theodus/micro-pony-plugin            |
-| `editorconfig`  | EditorConfig Support for micro                          | https://github.com/10sr/editorconfig-micro              |
-| `crystal`       | Provides various `crystal` tools for crystal files      | https://github.com/ColinRioux/micro-crystal             |
-| `gotham-colors` | A colorscheme for code that never sleeps in Gotham City | https://github.com/novln/micro-gotham-colors            |
-| `misspell`      | Plugin that corrects commonly misspelled words          | https://github.com/onodera-punpun/micro-misspell-plugin |
-| `monokai-dark`  | A dark monokai colorscheme                              | https://github.com/Theodus/micro-monokai-dark           |
-| `scratch`       | Plugin to create scratch buffers                        | https://github.com/samdmarshall/micro-scratch-plugin    |
-| `manipulator`   | Extend text manipulation abilities                      | https://github.com/NicolaiSoeborg/manipulator-plugin    |
-| `filemanager`   | A file manager!                                         | https://github.com/NicolaiSoeborg/filemanager-plugin    |
-| `vcs`           | Mark changed lines in Git or Mercurial repositories     | https://bitbucket.org/dermetfan/micro-vcs               |
-| `fmt`           | A multi-language formatting plugin                      | https://github.com/sum01/fmt-micro                      |
-| `joinLines`     | Plugin which joins selected lines or the following with the current | https://github.com/Lisiadito/join-lines-plugin |
+| Plugin          | Description                                             | Link                                                       | 2.0 Support                              |
+| --------------- | ------------------------------------------------------- | -------------------------------------------------------    | ---------------------------------------- |
+| `comment`       | Plugin to auto comment or uncomment lines               | https://github.com/micro-editor/comment-plugin             | :heavy_check_mark: (provided by default) |
+| `snippets`      | Provides snippets functionality                         | https://github.com/tommyshem/micro-snippets-plugin         | :heavy_check_mark:                       |
+| `go`            | Provides `gofmt` and `goimports` support for Go files   | https://github.com/micro-editor/go-plugin                  | :heavy_check_mark:                       |
+| `fish`          | Provides `fishfmt` support for Fish files               | https://github.com/onodera-punpun/micro-fish-plugin        | :heavy_check_mark:                       |
+| `wc`            | Plugin to count words/characters                        | https://github.com/adamnpeace/micro-wc-plugin              | :heavy_check_mark:                       |
+| `fzf`           | Provides `fzf` support for opening files                | https://github.com/samdmarshall/micro-fzf-plugin           | :heavy_check_mark:                       |
+| `pony`          | Provides auto-indentation for Pony files                | https://github.com/Theodus/micro-pony-plugin               | :heavy_check_mark:                       |
+| `editorconfig`  | EditorConfig Support for micro                          | https://github.com/10sr/editorconfig-micro                 | :heavy_check_mark:                       |
+| `crystal`       | Provides various `crystal` tools for crystal files      | https://github.com/ColinRioux/micro-crystal                | :heavy_check_mark:                       |
+| `gotham-colors` | A colorscheme for code that never sleeps in Gotham City | https://github.com/novln/micro-gotham-colors               | :heavy_check_mark: (provided by default) |
+| `misspell`      | Plugin that corrects commonly misspelled words          | https://github.com/onodera-punpun/micro-misspell-plugin    | :heavy_check_mark:                       |
+| `monokai-dark`  | A dark monokai colorscheme                              | https://github.com/Theodus/micro-monokai-dark              | :heavy_check_mark: (provided by default) |
+| `scratch`       | Plugin to create scratch buffers                        | https://github.com/samdmarshall/micro-scratch-plugin       | :x:                                      |
+| `manipulator`   | Extend text manipulation abilities                      | https://github.com/NicolaiSoeborg/manipulator-plugin       | :heavy_check_mark:                       |
+| `filemanager`   | A file manager!                                         | https://github.com/NicolaiSoeborg/filemanager-plugin       | :heavy_check_mark:                       |
+| `vcs`           | Mark changed lines in Git or Mercurial repositories     | https://bitbucket.org/dermetfan/micro-vcs                  | :heavy_check_mark: (provided by default) |
+| `fmt`           | A multi-language formatting plugin                      | https://github.com/sum01/fmt-micro                         | :x:                                      |
+| `joinLines`     | Plugin which joins selected lines or the following with the current | https://github.com/Lisiadito/join-lines-plugin | :heavy_check_mark:                       |
 
 ## Adding your own plugin
 

--- a/README.md
+++ b/README.md
@@ -4,14 +4,15 @@ This repository contains the 'channel.json' file which lists all official micro 
 
 ## Plugins
 
-| Plugin      | Description                                           | Link                                                |
-| ----------- | ----------------------------------------------------- | --------------------------------------------------- |
-| `comment`   | Plugin to auto comment or uncomment lines             | https://github.com/micro-editor/comment-plugin      |
-| `snippets`  | Provides snippets functionality                       | https://github.com/boombuler/microsnippets          |
-| `go`        | Provides `gofmt` and `goimports` support for Go files | https://github.com/micro-editor/go-plugin           |
-| `fish`      | Provides `fishfmt` support for Fish files             | https://github.com/onodera-punpun/micro-fish-plugin |
-| `wc`        | Plugin to count words/characters                      | https://github.com/adamnpeace/micro-wc-plugin       |
-| `fzf`       | Provides `fzf` support for opening files              | https://github.com/samdmarshall/micro-fzf-plugin    |
+| Plugin         | Description                                           | Link                                                |
+| -------------- | ----------------------------------------------------- | --------------------------------------------------- |
+| `comment`      | Plugin to auto comment or uncomment lines             | https://github.com/micro-editor/comment-plugin      |
+| `snippets`     | Provides snippets functionality                       | https://github.com/boombuler/microsnippets          |
+| `go`           | Provides `gofmt` and `goimports` support for Go files | https://github.com/micro-editor/go-plugin           |
+| `fish`         | Provides `fishfmt` support for Fish files             | https://github.com/onodera-punpun/micro-fish-plugin |
+| `wc`           | Plugin to count words/characters                      | https://github.com/adamnpeace/micro-wc-plugin       |
+| `fzf`          | Provides `fzf` support for opening files              | https://github.com/samdmarshall/micro-fzf-plugin    |
+| `editorconfig` | EditorConfig Support for micro                        | https://github.com/10sr/editorconfig-micro          |
 
 ## Adding your own plugin
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `quoter`     | Plugin that allows you to add quotes or brackets around selected text | https://github.com/deusnefum/micro-quoter | :heavy_check_mark:                       |
 | `zigfmt`        | Provides `zig fmt` integration for Zig files            | https://github.com/squeek502/micro-zigfmt                  | :heavy_check_mark:                       |
 | `jlabbrev`      | Provides backslash abbreviations from the julia prompt  | https://github.com/MasFlam/jlabbrev                        | :heavy_check_mark:                       |
+| `nord-tc`      | A dark colorscheme based on Nord  | https://github.com/KiranWells/micro-nord-tc-colors                        | :heavy_check_mark:                       |
 
 ## Adding your own plugin
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `joinLines`     | Plugin which joins selected lines or the following with the current | https://github.com/Lisiadito/join-lines-plugin | :heavy_check_mark:                       |
 | `bounce`     | Plugin that implements nano-style smart home and bouncing the cursor between matching-brackets | https://github.com/deusnefum/micro-bounce | :heavy_check_mark:                       |
 | `quoter`     | Plugin that allows you to add quotes or brackets around selected text | https://github.com/deusnefum/micro-quoter | :heavy_check_mark:                       |
+| `zigfmt`        | Provides `zig fmt` integration for Zig files            | https://github.com/squeek502/micro-zigfmt                  | :heavy_check_mark:                       |
 
 ## Adding your own plugin
 

--- a/channel.json
+++ b/channel.json
@@ -57,5 +57,8 @@
   "https://raw.githubusercontent.com/deusnefum/micro-bounce/master/repo.json",
 
   // zigfmt plugin
-  "https://raw.githubusercontent.com/squeek502/micro-zigfmt/master/repo.json"
+  "https://raw.githubusercontent.com/squeek502/micro-zigfmt/master/repo.json",
+  
+  // Aspell plugin
+  "https://raw.githubusercontent.com/priner/micro-aspell-plugin/master/repo.json"
 ]

--- a/channel.json
+++ b/channel.json
@@ -54,5 +54,8 @@
   "https://raw.githubusercontent.com/deusnefum/micro-quoter/master/repo.json",
   
   // Bounce plugin
-  "https://raw.githubusercontent.com/deusnefum/micro-bounce/master/repo.json"
+  "https://raw.githubusercontent.com/deusnefum/micro-bounce/master/repo.json",
+
+  // zigfmt plugin
+  "https://raw.githubusercontent.com/squeek502/micro-zigfmt/master/repo.json"
 ]

--- a/channel.json
+++ b/channel.json
@@ -48,5 +48,8 @@
   "https://raw.githubusercontent.com/computerers/micro-rubocop/master/repo.json",
 
   // VCS plugin
-  "https://bitbucket.org/dermetfan/micro-vcs/raw/default/repo.json"
+  "https://bitbucket.org/dermetfan/micro-vcs/raw/default/repo.json",
+
+  // fmt plugin
+  "https://github.com/sum01/fmt-micro/raw/master/repo.json"
 ]

--- a/channel.json
+++ b/channel.json
@@ -18,7 +18,7 @@
    "https://raw.githubusercontent.com/micro-editor/updated-plugins/master/micro-snippets-plugin/repo.json",
 
   // wc plugin
-  "https://raw.githubusercontent.com/adamnpeace/micro-wc-plugin/master/repo.json",
+  "https://raw.githubusercontent.com/micro-editor/updated-plugins/master/micro-wc-plugin/repo.json",
 
   // Pony plugin
   "https://raw.githubusercontent.com/micro-editor/updated-plugins/master/micro-pony-plugin/repo.json",

--- a/channel.json
+++ b/channel.json
@@ -67,4 +67,7 @@
 
   // wakatime plugin
   "https://raw.githubusercontent.com/wakatime/micro-wakatime/master/repo.json"
+  
+  // nord-tc colorscheme
+  "https://raw.githubusercontent.com/KiranWells/micro-nord-tc-colors/main/repo.json"
 ]

--- a/channel.json
+++ b/channel.json
@@ -80,6 +80,9 @@
   // quickfix plugin
   "https://raw.githubusercontent.com/serge-v/micro-quickfix/main/repo.json",
 
+  // jump plugin
+  "https://raw.githubusercontent.com/terokarvinen/micro-jump/main/repo.json"
+
   // detectindent plugin
   "https://raw.githubusercontent.com/dmaluka/micro-detectindent/master/repo.json"
 ]

--- a/channel.json
+++ b/channel.json
@@ -12,7 +12,7 @@
   "https://raw.githubusercontent.com/micro-editor/updated-plugins/master/fzf/repo.json",
 
   // Go plugin
-  "https://raw.githubusercontent.com/micro-editor/go-plugin/master/repo.json",
+  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/go.json",
 
   // Snippets plugin
    "https://raw.githubusercontent.com/micro-editor/updated-plugins/master/micro-snippets-plugin/repo.json",

--- a/channel.json
+++ b/channel.json
@@ -19,10 +19,13 @@
 
   // wc plugin
   "https://raw.githubusercontent.com/adamnpeace/micro-wc-plugin/master/repo.json",
-  
+
   // Pony plugin
   "https://raw.githubusercontent.com/Theodus/micro-pony-plugin/master/repo.json",
 
   // Crystal plugin
   "https://raw.githubusercontent.com/ColinRioux/micro-crystal/master/repo.json"
+
+  // Misspell plugin
+  "https://raw.githubusercontent.com/onodera-punpun/micro-misspell-plugin/master/repo.json"
 ]

--- a/channel.json
+++ b/channel.json
@@ -41,6 +41,9 @@
   // Manipulator plugin
   "https://raw.githubusercontent.com/NicolaiSoeborg/manipulator-plugin/master/repo.json",
 
+  // Filemanager plugin
+  "https://raw.githubusercontent.com/NicolaiSoeborg/filemanager-plugin/master/repo.json",
+  
   // Rubocop plugin
   "https://raw.githubusercontent.com/computerers/micro-rubocop/master/repo.json",
 

--- a/channel.json
+++ b/channel.json
@@ -72,5 +72,8 @@
   "https://raw.githubusercontent.com/KiranWells/micro-nord-tc-colors/main/repo.json",
 
   // yapf plugin
-  "https://raw.githubusercontent.com/a11ce/micro-yapf/master/repo.json"
+  "https://raw.githubusercontent.com/a11ce/micro-yapf/master/repo.json",
+
+  // quickfix plugin
+  "https://raw.githubusercontent.com/serge-v/micro-quickfix/main/repo.json"
 ]

--- a/channel.json
+++ b/channel.json
@@ -68,6 +68,6 @@
   // wakatime plugin
   "https://raw.githubusercontent.com/wakatime/micro-wakatime/master/repo.json",
   
-  // nord-tc colorscheme
+  // nord colorschemes
   "https://raw.githubusercontent.com/KiranWells/micro-nord-tc-colors/main/repo.json"
 ]

--- a/channel.json
+++ b/channel.json
@@ -69,7 +69,7 @@
   "https://raw.githubusercontent.com/wakatime/micro-wakatime/master/repo.json",
   
   // nord colorschemes
-  "https://raw.githubusercontent.com/KiranWells/micro-nord-tc-colors/main/repo.json"
+  "https://raw.githubusercontent.com/KiranWells/micro-nord-tc-colors/main/repo.json",
 
   // yapf plugin
   "https://raw.githubusercontent.com/a11ce/micro-yapf/master/repo.json"

--- a/channel.json
+++ b/channel.json
@@ -3,7 +3,7 @@
   "https://raw.githubusercontent.com/micro-editor/comment-plugin/master/repo.json",
 
   // EditorConfig plugin
-  "https://raw.githubusercontent.com/micro-editor/updated-plugins/master/editorconfig-micro/repo.json",
+  "https://raw.githubusercontent.com/10sr/editorconfig-micro/master/repo.json",
 
   // Fish plugin
   "https://raw.githubusercontent.com/micro-editor/updated-plugins/master/micro-fish-plugin/repo.json",

--- a/channel.json
+++ b/channel.json
@@ -5,12 +5,15 @@
   // Fish plugin
   "https://raw.githubusercontent.com/onodera-punpun/micro-fish-plugin/master/repo.json",
 
+  // fzf plugin
+  "https://raw.githubusercontent.com/samdmarshall/micro-fzf-plugin/master/repo.json",
+
   // Go plugin
   "https://raw.githubusercontent.com/micro-editor/go-plugin/master/repo.json",
 
   // Snippets plugin
   "https://raw.githubusercontent.com/boombuler/microsnippets/master/repo.json",
-  
+
   // wc plugin
   "https://raw.githubusercontent.com/adamnpeace/micro-wc-plugin/master/repo.json"
 ]

--- a/channel.json
+++ b/channel.json
@@ -15,7 +15,7 @@
   "https://raw.githubusercontent.com/micro-editor/go-plugin/master/repo.json",
 
   // Snippets plugin
-  "https://raw.githubusercontent.com/boombuler/microsnippets/master/repo.json",
+   "https://raw.githubusercontent.com/tommyshem/micro-snippets-plugin/master/repo.json",
 
   // wc plugin
   "https://raw.githubusercontent.com/adamnpeace/micro-wc-plugin/master/repo.json",

--- a/channel.json
+++ b/channel.json
@@ -42,5 +42,8 @@
   "https://raw.githubusercontent.com/NicolaiSoeborg/manipulator-plugin/master/repo.json",
 
   // Filemanager plugin
-  "https://raw.githubusercontent.com/NicolaiSoeborg/filemanager-plugin/master/repo.json"
+  "https://raw.githubusercontent.com/NicolaiSoeborg/filemanager-plugin/master/repo.json",
+  
+  // Rubocop plugin
+  "https://raw.githubusercontent.com/computerers/micro-rubocop/master/repo.json"
 ]

--- a/channel.json
+++ b/channel.json
@@ -37,10 +37,13 @@
 
   // scratch file plugin
   "https://raw.githubusercontent.com/samdmarshall/micro-scratch-plugin/master/repo.json",
-  
+
   // Manipulator plugin
   "https://raw.githubusercontent.com/NicolaiSoeborg/manipulator-plugin/master/repo.json",
-  
+
   // Rubocop plugin
-  "https://raw.githubusercontent.com/computerers/micro-rubocop/master/repo.json"
+  "https://raw.githubusercontent.com/computerers/micro-rubocop/master/repo.json",
+
+  // VCS plugin
+  "https://bitbucket.org/dermetfan/micro-vcs/raw/default/repo.json"
 ]

--- a/channel.json
+++ b/channel.json
@@ -78,5 +78,8 @@
   "https://raw.githubusercontent.com/haqk/micro-bookmark/main/repo.json",
 
   // quickfix plugin
-  "https://raw.githubusercontent.com/serge-v/micro-quickfix/main/repo.json"
+  "https://raw.githubusercontent.com/serge-v/micro-quickfix/main/repo.json",
+
+  // detectindent plugin
+  "https://raw.githubusercontent.com/dmaluka/micro-detectindent/master/repo.json"
 ]

--- a/channel.json
+++ b/channel.json
@@ -33,5 +33,8 @@
   "https://raw.githubusercontent.com/novln/micro-gotham-colors/master/repo.json",
 
   // monokai-dark colorscheme
-  "https://raw.githubusercontent.com/Theodus/micro-monokai-dark/master/repo.json"
+  "https://raw.githubusercontent.com/Theodus/micro-monokai-dark/master/repo.json",
+  
+  // Manipulator plugin
+  "https://raw.githubusercontent.com/NicolaiSoeborg/manipulator-plugin/master/repo.json"
 ]

--- a/channel.json
+++ b/channel.json
@@ -48,5 +48,11 @@
   "https://raw.githubusercontent.com/sum01/fmt-micro/master/repo.json",
 
   // JoinLines plugin
-  "https://raw.githubusercontent.com/micro-editor/updated-plugins/master/join-lines-plugin/repo.json"
+  "https://raw.githubusercontent.com/micro-editor/updated-plugins/master/join-lines-plugin/repo.json",
+  
+  // Quoter plugin
+  "https://raw.githubusercontent.com/deusnefum/micro-quoter/v1.0.0/repo.json",
+  
+  // Bounce plugin
+  "https://raw.githubusercontent.com/deusnefum/micro-bounce/v1.0.0/repo.json"
 ]

--- a/channel.json
+++ b/channel.json
@@ -84,5 +84,8 @@
   "https://raw.githubusercontent.com/terokarvinen/micro-jump/main/repo.json",
 
   // detectindent plugin
-  "https://raw.githubusercontent.com/dmaluka/micro-detectindent/master/repo.json"
+  "https://raw.githubusercontent.com/dmaluka/micro-detectindent/master/repo.json",
+
+  // lsp plugin
+  "https://raw.githubusercontent.com/andcake/micro-plugin-lsp/master/repo.json"
 ]

--- a/channel.json
+++ b/channel.json
@@ -43,9 +43,6 @@
 
   // Filemanager plugin
   "https://raw.githubusercontent.com/NicolaiSoeborg/filemanager-plugin/master/repo.json",
-  
-  // Rubocop plugin
-  "https://raw.githubusercontent.com/computerers/micro-rubocop/master/repo.json",
 
   // VCS plugin
   "https://bitbucket.org/dermetfan/micro-vcs/raw/default/repo.json",

--- a/channel.json
+++ b/channel.json
@@ -63,7 +63,7 @@
   "https://raw.githubusercontent.com/priner/micro-aspell-plugin/master/repo.json",
   
   // jlabbrev plugin
-  "https://raw.githubusercontent.com/MasFlam/jlabbrev/master/repo.json"
+  "https://raw.githubusercontent.com/MasFlam/jlabbrev/master/repo.json",
 
   // wakatime plugin
   "https://raw.githubusercontent.com/wakatime/micro-wakatime/master/repo.json"

--- a/channel.json
+++ b/channel.json
@@ -1,7 +1,4 @@
 [
-  // Comment plugin
-  "https://raw.githubusercontent.com/micro-editor/comment-plugin/master/repo.json",
-
   // EditorConfig plugin
   "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/editorconfig-micro.json",
 

--- a/channel.json
+++ b/channel.json
@@ -51,8 +51,8 @@
   "https://raw.githubusercontent.com/micro-editor/updated-plugins/master/join-lines-plugin/repo.json",
   
   // Quoter plugin
-  "https://raw.githubusercontent.com/deusnefum/micro-quoter/v1.0.0/repo.json",
+  "https://raw.githubusercontent.com/deusnefum/micro-quoter/master/repo.json",
   
   // Bounce plugin
-  "https://raw.githubusercontent.com/deusnefum/micro-bounce/v1.0.0/repo.json"
+  "https://raw.githubusercontent.com/deusnefum/micro-bounce/master/repo.json"
 ]

--- a/channel.json
+++ b/channel.json
@@ -48,7 +48,7 @@
   "https://bitbucket.org/dermetfan/micro-vcs/raw/default/repo.json",
 
   // fmt plugin
-  "https://raw.githubusercontent.com/sum01/fmt-micro/master/repo.json"
+  "https://raw.githubusercontent.com/sum01/fmt-micro/master/repo.json",
 
   // JoinLines plugin
   "https://raw.githubusercontent.com/Lisiadito/join-lines-plugin/master/repo.json"

--- a/channel.json
+++ b/channel.json
@@ -81,7 +81,7 @@
   "https://raw.githubusercontent.com/serge-v/micro-quickfix/main/repo.json",
 
   // jump plugin
-  "https://raw.githubusercontent.com/terokarvinen/micro-jump/main/repo.json"
+  "https://raw.githubusercontent.com/terokarvinen/micro-jump/main/repo.json",
 
   // detectindent plugin
   "https://raw.githubusercontent.com/dmaluka/micro-detectindent/master/repo.json"

--- a/channel.json
+++ b/channel.json
@@ -30,7 +30,7 @@
   "https://raw.githubusercontent.com/ColinRioux/micro-crystal/master/repo.json",
 
   // Gotham colorscheme
-  "https://raw.githubusercontent.com/november-eleven/micro-gotham-colors/master/repo.json",
+  "https://raw.githubusercontent.com/novln/micro-gotham-colors/master/repo.json",
 
   // monokai-dark colorscheme
   "https://raw.githubusercontent.com/Theodus/micro-monokai-dark/master/repo.json"

--- a/channel.json
+++ b/channel.json
@@ -23,6 +23,9 @@
   // Pony plugin
   "https://raw.githubusercontent.com/Theodus/micro-pony-plugin/master/repo.json",
 
+  // Misspell plugin
+  "https://raw.githubusercontent.com/onodera-punpun/micro-misspell-plugin/master/repo.json"
+
   // Crystal plugin
   "https://raw.githubusercontent.com/ColinRioux/micro-crystal/master/repo.json",
 

--- a/channel.json
+++ b/channel.json
@@ -29,6 +29,12 @@
   // Crystal plugin
   "https://raw.githubusercontent.com/ColinRioux/micro-crystal/master/repo.json",
 
+  // Gotham colorscheme
+  "https://raw.githubusercontent.com/novln/micro-gotham-colors/master/repo.json",
+
+  // monokai-dark colorscheme
+  "https://raw.githubusercontent.com/Theodus/micro-monokai-dark/master/repo.json",
+
   // scratch file plugin
   "https://raw.githubusercontent.com/samdmarshall/micro-scratch-plugin/master/repo.json",
 

--- a/channel.json
+++ b/channel.json
@@ -36,5 +36,8 @@
   "https://raw.githubusercontent.com/Theodus/micro-monokai-dark/master/repo.json",
   
   // Manipulator plugin
-  "https://raw.githubusercontent.com/NicolaiSoeborg/manipulator-plugin/master/repo.json"
+  "https://raw.githubusercontent.com/NicolaiSoeborg/manipulator-plugin/master/repo.json",
+
+  // Filemanager plugin
+  "https://raw.githubusercontent.com/NicolaiSoeborg/filemanager-plugin/master/repo.json"
 ]

--- a/channel.json
+++ b/channel.json
@@ -3,7 +3,7 @@
   "https://raw.githubusercontent.com/micro-editor/comment-plugin/master/repo.json",
 
   // EditorConfig plugin
-  "https://raw.githubusercontent.com/10sr/editorconfig-micro/master/repo.json",
+  "https://raw.githubusercontent.com/10sr/editorconfig-micro/0d5d60520799ade785f120215a454f1117270ef3/repo.json",
 
   // Fish plugin
   "https://raw.githubusercontent.com/onodera-punpun/micro-fish-plugin/master/repo.json",

--- a/channel.json
+++ b/channel.json
@@ -73,4 +73,7 @@
 
   // yapf plugin
   "https://raw.githubusercontent.com/a11ce/micro-yapf/master/repo.json"
+
+  // bookmark plugin
+  "https://raw.githubusercontent.com/haqk/micro-bookmark/main/repo.json"
 ]

--- a/channel.json
+++ b/channel.json
@@ -27,5 +27,8 @@
   "https://raw.githubusercontent.com/ColinRioux/micro-crystal/master/repo.json",
 
   // Gotham colorscheme
-  "https://raw.githubusercontent.com/november-eleven/micro-gotham-colors/master/repo.json"
+  "https://raw.githubusercontent.com/november-eleven/micro-gotham-colors/master/repo.json",
+
+  // monokai-dark colorscheme
+  "https://raw.githubusercontent.com/Theodus/micro-monokai-dark/master/repo.json"
 ]

--- a/channel.json
+++ b/channel.json
@@ -15,5 +15,8 @@
   "https://raw.githubusercontent.com/boombuler/microsnippets/master/repo.json",
 
   // wc plugin
-  "https://raw.githubusercontent.com/adamnpeace/micro-wc-plugin/master/repo.json"
+  "https://raw.githubusercontent.com/adamnpeace/micro-wc-plugin/master/repo.json",
+  
+  // Pony plugin
+  "https://raw.githubusercontent.com/Theodus/micro-pony-plugin/master/repo.json"
 ]

--- a/channel.json
+++ b/channel.json
@@ -27,7 +27,7 @@
   "https://raw.githubusercontent.com/micro-editor/updated-plugins/master/micro-crystal/repo.json",
 
   // Gotham colorscheme
-  "https://raw.githubusercontent.com/nmicro-editor/plugin-channel/master/plugins/micro-gotham-colors.json",
+  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-gotham-colors.json",
 
   // monokai-dark colorscheme
   "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-monokai-dark.json",
@@ -63,7 +63,7 @@
   "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-nord-tc-colors.json",
 
   // yapf plugin
-  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-yapf.json",
+  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-autofmt.json",
 
   // bookmark plugin
   "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-bookmark.json",

--- a/channel.json
+++ b/channel.json
@@ -29,12 +29,6 @@
   // Crystal plugin
   "https://raw.githubusercontent.com/ColinRioux/micro-crystal/master/repo.json",
 
-  // Gotham colorscheme
-  "https://raw.githubusercontent.com/novln/micro-gotham-colors/master/repo.json",
-
-  // monokai-dark colorscheme
-  "https://raw.githubusercontent.com/Theodus/micro-monokai-dark/master/repo.json",
-
   // scratch file plugin
   "https://raw.githubusercontent.com/samdmarshall/micro-scratch-plugin/master/repo.json",
 

--- a/channel.json
+++ b/channel.json
@@ -66,7 +66,7 @@
   "https://raw.githubusercontent.com/MasFlam/jlabbrev/master/repo.json",
 
   // wakatime plugin
-  "https://raw.githubusercontent.com/wakatime/micro-wakatime/master/repo.json"
+  "https://raw.githubusercontent.com/wakatime/micro-wakatime/master/repo.json",
   
   // nord-tc colorscheme
   "https://raw.githubusercontent.com/KiranWells/micro-nord-tc-colors/main/repo.json"

--- a/channel.json
+++ b/channel.json
@@ -24,7 +24,7 @@
   "https://raw.githubusercontent.com/Theodus/micro-pony-plugin/master/repo.json",
 
   // Misspell plugin
-  "https://raw.githubusercontent.com/onodera-punpun/micro-misspell-plugin/master/repo.json"
+  "https://raw.githubusercontent.com/onodera-punpun/micro-misspell-plugin/master/repo.json",
 
   // Crystal plugin
   "https://raw.githubusercontent.com/ColinRioux/micro-crystal/master/repo.json",

--- a/channel.json
+++ b/channel.json
@@ -21,5 +21,8 @@
   "https://raw.githubusercontent.com/adamnpeace/micro-wc-plugin/master/repo.json",
   
   // Pony plugin
-  "https://raw.githubusercontent.com/Theodus/micro-pony-plugin/master/repo.json"
+  "https://raw.githubusercontent.com/Theodus/micro-pony-plugin/master/repo.json",
+
+  // Crystal plugin
+  "https://raw.githubusercontent.com/ColinRioux/micro-crystal/master/repo.json"
 ]

--- a/channel.json
+++ b/channel.json
@@ -3,31 +3,31 @@
   "https://raw.githubusercontent.com/micro-editor/comment-plugin/master/repo.json",
 
   // EditorConfig plugin
-  "https://raw.githubusercontent.com/10sr/editorconfig-micro/0d5d60520799ade785f120215a454f1117270ef3/repo.json",
+  "https://raw.githubusercontent.com/micro-editor/updated-plugins/master/editorconfig-micro/repo.json",
 
   // Fish plugin
-  "https://raw.githubusercontent.com/onodera-punpun/micro-fish-plugin/master/repo.json",
+  "https://raw.githubusercontent.com/micro-editor/updated-plugins/master/micro-fish-plugin/repo.json",
 
   // fzf plugin
-  "https://raw.githubusercontent.com/samdmarshall/micro-fzf-plugin/master/repo.json",
+  "https://raw.githubusercontent.com/micro-editor/updated-plugins/master/fzf/repo.json",
 
   // Go plugin
   "https://raw.githubusercontent.com/micro-editor/go-plugin/master/repo.json",
 
   // Snippets plugin
-   "https://raw.githubusercontent.com/tommyshem/micro-snippets-plugin/master/repo.json",
+   "https://raw.githubusercontent.com/micro-editor/updated-plugins/master/micro-snippets-plugin/repo.json",
 
   // wc plugin
-  "https://raw.githubusercontent.com/adamnpeace/micro-wc-plugin/master/repo.json",
+  "https://raw.githubusercontent.com/micro-editor/updated-plugins/master/micro-wc-plugin/repo.json",
 
   // Pony plugin
-  "https://raw.githubusercontent.com/Theodus/micro-pony-plugin/master/repo.json",
+  "https://raw.githubusercontent.com/micro-editor/updated-plugins/master/micro-pony-plugin/repo.json",
 
   // Misspell plugin
-  "https://raw.githubusercontent.com/onodera-punpun/micro-misspell-plugin/master/repo.json",
+  "https://raw.githubusercontent.com/micro-editor/updated-plugins/master/micro-misspell-plugin/repo.json",
 
   // Crystal plugin
-  "https://raw.githubusercontent.com/ColinRioux/micro-crystal/master/repo.json",
+  "https://raw.githubusercontent.com/micro-editor/updated-plugins/master/micro-crystal/repo.json",
 
   // Gotham colorscheme
   "https://raw.githubusercontent.com/novln/micro-gotham-colors/master/repo.json",
@@ -39,17 +39,14 @@
   "https://raw.githubusercontent.com/samdmarshall/micro-scratch-plugin/master/repo.json",
 
   // Manipulator plugin
-  "https://raw.githubusercontent.com/NicolaiSoeborg/manipulator-plugin/master/repo.json",
+  "https://raw.githubusercontent.com/micro-editor/updated-plugins/master/manipulator-plugin/repo.json",
 
   // Filemanager plugin
-  "https://raw.githubusercontent.com/NicolaiSoeborg/filemanager-plugin/master/repo.json",
-
-  // VCS plugin
-  "https://bitbucket.org/dermetfan/micro-vcs/raw/default/repo.json",
+  "https://raw.githubusercontent.com/micro-editor/updated-plugins/master/filemanager-plugin/repo.json",
 
   // fmt plugin
   "https://raw.githubusercontent.com/sum01/fmt-micro/master/repo.json",
 
   // JoinLines plugin
-  "https://raw.githubusercontent.com/Lisiadito/join-lines-plugin/master/repo.json"
+  "https://raw.githubusercontent.com/micro-editor/updated-plugins/master/join-lines-plugin/repo.json"
 ]

--- a/channel.json
+++ b/channel.json
@@ -19,10 +19,13 @@
 
   // wc plugin
   "https://raw.githubusercontent.com/adamnpeace/micro-wc-plugin/master/repo.json",
-  
+
   // Pony plugin
   "https://raw.githubusercontent.com/Theodus/micro-pony-plugin/master/repo.json",
 
   // Crystal plugin
-  "https://raw.githubusercontent.com/ColinRioux/micro-crystal/master/repo.json"
+  "https://raw.githubusercontent.com/ColinRioux/micro-crystal/master/repo.json",
+
+  // Gotham colorscheme
+  "https://raw.githubusercontent.com/november-eleven/micro-gotham-colors/master/repo.json"
 ]

--- a/channel.json
+++ b/channel.json
@@ -40,9 +40,6 @@
   
   // Manipulator plugin
   "https://raw.githubusercontent.com/NicolaiSoeborg/manipulator-plugin/master/repo.json",
-
-  // Filemanager plugin
-  "https://raw.githubusercontent.com/NicolaiSoeborg/filemanager-plugin/master/repo.json",
   
   // Rubocop plugin
   "https://raw.githubusercontent.com/computerers/micro-rubocop/master/repo.json"

--- a/channel.json
+++ b/channel.json
@@ -49,4 +49,7 @@
 
   // fmt plugin
   "https://raw.githubusercontent.com/sum01/fmt-micro/master/repo.json"
+
+  // JoinLines plugin
+  "https://raw.githubusercontent.com/Lisiadito/join-lines-plugin/master/repo.json"
 ]

--- a/channel.json
+++ b/channel.json
@@ -70,4 +70,7 @@
   
   // nord colorschemes
   "https://raw.githubusercontent.com/KiranWells/micro-nord-tc-colors/main/repo.json"
+
+  // yapf plugin
+  "https://raw.githubusercontent.com/a11ce/micro-yapf/master/repo.json"
 ]

--- a/channel.json
+++ b/channel.json
@@ -48,7 +48,7 @@
   "https://raw.githubusercontent.com/sum01/fmt-micro/master/repo.json",
 
   // JoinLines plugin
-  "https://raw.githubusercontent.com/micro-editor/updated-plugins/master/join-lines-plugin/repo.json",
+  "https://raw.githubusercontent.com/Lisiadito/join-lines-plugin/master/repo.json",
   
   // Quoter plugin
   "https://raw.githubusercontent.com/deusnefum/micro-quoter/master/repo.json",

--- a/channel.json
+++ b/channel.json
@@ -64,4 +64,7 @@
   
   // jlabbrev plugin
   "https://raw.githubusercontent.com/MasFlam/jlabbrev/master/repo.json"
+
+  // wakatime plugin
+  "https://raw.githubusercontent.com/wakatime/micro-wakatime/master/repo.json"
 ]

--- a/channel.json
+++ b/channel.json
@@ -33,5 +33,8 @@
   "https://raw.githubusercontent.com/november-eleven/micro-gotham-colors/master/repo.json",
 
   // monokai-dark colorscheme
-  "https://raw.githubusercontent.com/Theodus/micro-monokai-dark/master/repo.json"
+  "https://raw.githubusercontent.com/Theodus/micro-monokai-dark/master/repo.json",
+
+  // scratch file plugin
+  "https://raw.githubusercontent.com/samdmarshall/micro-scratch-plugin/master/repo.json"
 ]

--- a/channel.json
+++ b/channel.json
@@ -51,5 +51,5 @@
   "https://bitbucket.org/dermetfan/micro-vcs/raw/default/repo.json",
 
   // fmt plugin
-  "https://github.com/sum01/fmt-micro/raw/master/repo.json"
+  "https://raw.githubusercontent.com/sum01/fmt-micro/master/repo.json"
 ]

--- a/channel.json
+++ b/channel.json
@@ -12,7 +12,7 @@
   "https://raw.githubusercontent.com/samdmarshall/micro-fzf-plugin/master/repo.json",
 
   // Go plugin
-  "https://raw.githubusercontent.com/micro-editor/go-plugin/039a4a7ad630ae3cefb355f12321aef97adb758c/repo.json",
+  "https://raw.githubusercontent.com/micro-editor/go-plugin/master/repo.json",
 
   // Snippets plugin
    "https://raw.githubusercontent.com/tommyshem/micro-snippets-plugin/master/repo.json",

--- a/channel.json
+++ b/channel.json
@@ -12,7 +12,7 @@
   "https://raw.githubusercontent.com/samdmarshall/micro-fzf-plugin/master/repo.json",
 
   // Go plugin
-  "https://raw.githubusercontent.com/micro-editor/go-plugin/master/repo.json",
+  "https://raw.githubusercontent.com/micro-editor/go-plugin/039a4a7ad630ae3cefb355f12321aef97adb758c/repo.json",
 
   // Snippets plugin
    "https://raw.githubusercontent.com/tommyshem/micro-snippets-plugin/master/repo.json",

--- a/channel.json
+++ b/channel.json
@@ -3,7 +3,7 @@
   "https://raw.githubusercontent.com/micro-editor/comment-plugin/master/repo.json",
 
   // EditorConfig plugin
-  "https://raw.githubusercontent.com/10sr/editorconfig-micro/master/repo.json",
+  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/editorconfig-micro.json",
 
   // Fish plugin
   "https://raw.githubusercontent.com/micro-editor/updated-plugins/master/micro-fish-plugin/repo.json",
@@ -30,13 +30,10 @@
   "https://raw.githubusercontent.com/micro-editor/updated-plugins/master/micro-crystal/repo.json",
 
   // Gotham colorscheme
-  "https://raw.githubusercontent.com/novln/micro-gotham-colors/master/repo.json",
+  "https://raw.githubusercontent.com/nmicro-editor/plugin-channel/master/plugins/micro-gotham-colors.json",
 
   // monokai-dark colorscheme
-  "https://raw.githubusercontent.com/Theodus/micro-monokai-dark/master/repo.json",
-
-  // scratch file plugin
-  "https://raw.githubusercontent.com/samdmarshall/micro-scratch-plugin/master/repo.json",
+  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-monokai-dark.json",
 
   // Manipulator plugin
   "https://raw.githubusercontent.com/micro-editor/updated-plugins/master/manipulator-plugin/repo.json",
@@ -44,48 +41,45 @@
   // Filemanager plugin
   "https://raw.githubusercontent.com/micro-editor/updated-plugins/master/filemanager-plugin/repo.json",
 
-  // fmt plugin
-  "https://raw.githubusercontent.com/sum01/fmt-micro/master/repo.json",
-
   // JoinLines plugin
-  "https://raw.githubusercontent.com/Lisiadito/join-lines-plugin/master/repo.json",
+  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/join-lines-plugin.json",
   
   // Quoter plugin
-  "https://raw.githubusercontent.com/deusnefum/micro-quoter/master/repo.json",
+  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-quoter.json",
   
   // Bounce plugin
-  "https://raw.githubusercontent.com/deusnefum/micro-bounce/master/repo.json",
+  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-bounce.json",
 
   // zigfmt plugin
-  "https://raw.githubusercontent.com/squeek502/micro-zigfmt/master/repo.json",
+  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-zigfmt.json",
   
   // Aspell plugin
-  "https://raw.githubusercontent.com/priner/micro-aspell-plugin/master/repo.json",
+  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-aspell-plugin.json",
   
   // jlabbrev plugin
-  "https://raw.githubusercontent.com/MasFlam/jlabbrev/master/repo.json",
+  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/jlabbrev.json",
 
   // wakatime plugin
-  "https://raw.githubusercontent.com/wakatime/micro-wakatime/master/repo.json",
+  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-wakatime.json",
   
   // nord colorschemes
-  "https://raw.githubusercontent.com/KiranWells/micro-nord-tc-colors/main/repo.json",
+  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-nord-tc-colors.json",
 
   // yapf plugin
-  "https://raw.githubusercontent.com/a11ce/micro-yapf/master/repo.json",
+  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-yapf.json",
 
   // bookmark plugin
-  "https://raw.githubusercontent.com/haqk/micro-bookmark/main/repo.json",
+  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-bookmark.json",
 
   // quickfix plugin
-  "https://raw.githubusercontent.com/serge-v/micro-quickfix/main/repo.json",
+  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-quickfix.json",
 
   // jump plugin
-  "https://raw.githubusercontent.com/terokarvinen/micro-jump/main/repo.json",
+  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-jump.json",
 
   // detectindent plugin
-  "https://raw.githubusercontent.com/dmaluka/micro-detectindent/master/repo.json",
+  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-detectindent.json",
 
   // lsp plugin
-  "https://raw.githubusercontent.com/andcake/micro-plugin-lsp/master/repo.json"
+  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-plugin-lsp.json"
 ]

--- a/channel.json
+++ b/channel.json
@@ -18,7 +18,7 @@
    "https://raw.githubusercontent.com/micro-editor/updated-plugins/master/micro-snippets-plugin/repo.json",
 
   // wc plugin
-  "https://raw.githubusercontent.com/micro-editor/updated-plugins/master/micro-wc-plugin/repo.json",
+  "https://raw.githubusercontent.com/adamnpeace/micro-wc-plugin/master/repo.json",
 
   // Pony plugin
   "https://raw.githubusercontent.com/micro-editor/updated-plugins/master/micro-pony-plugin/repo.json",

--- a/channel.json
+++ b/channel.json
@@ -2,6 +2,9 @@
   // Comment plugin
   "https://raw.githubusercontent.com/micro-editor/comment-plugin/master/repo.json",
 
+  // EditorConfig plugin
+  "https://raw.githubusercontent.com/10sr/editorconfig-micro/master/repo.json",
+
   // Fish plugin
   "https://raw.githubusercontent.com/onodera-punpun/micro-fish-plugin/master/repo.json",
 

--- a/channel.json
+++ b/channel.json
@@ -60,5 +60,8 @@
   "https://raw.githubusercontent.com/squeek502/micro-zigfmt/master/repo.json",
   
   // Aspell plugin
-  "https://raw.githubusercontent.com/priner/micro-aspell-plugin/master/repo.json"
+  "https://raw.githubusercontent.com/priner/micro-aspell-plugin/master/repo.json",
+  
+  // jlabbrev plugin
+  "https://raw.githubusercontent.com/MasFlam/jlabbrev/master/repo.json"
 ]

--- a/plugins/editorconfig-micro.json
+++ b/plugins/editorconfig-micro.json
@@ -1,0 +1,15 @@
+[{
+  "Name": "editorconfig",
+  "Description": "EditorConfig plugin for micro",
+  "Tags": ["editorconfig", "utility", "format"],
+  "Website": "https://github.com/10sr/editorconfig-micro",
+  "Versions": [
+    {
+      "Version": "1.0.0",
+      "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/editorconfig-micro-1.0.0.zip",
+      "Require": {
+        "micro": ">=2.0.1"
+      }
+    }
+  ]
+}]

--- a/plugins/editorconfig-micro.json
+++ b/plugins/editorconfig-micro.json
@@ -3,6 +3,7 @@
   "Description": "EditorConfig plugin for micro",
   "Tags": ["editorconfig", "utility", "format"],
   "Website": "https://github.com/10sr/editorconfig-micro",
+  "License": "MIT",
   "Versions": [
     {
       "Version": "1.0.0",

--- a/plugins/go.json
+++ b/plugins/go.json
@@ -1,0 +1,22 @@
+[{
+  "Name": "go",
+  "Description": "Go language support (gofmt and goimports)",
+  "Tags": ["go", "golang"],
+  "Website": "https://github.com/micro-editor/go-plugin",
+  "Versions": [
+    {
+      "Version": "2.0.2",
+      "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/go-plugin-2.0.2.zip",
+      "Require": {
+        "micro": ">=2.0.0"
+      }
+    },
+    {
+      "Version": "1.0.1",
+      "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/go-plugin-1.0.1.zip",
+      "Require": {
+        "micro": ">=1.0.3 <2.0.0-1"
+      }
+    }
+  ]
+}]

--- a/plugins/go.json
+++ b/plugins/go.json
@@ -3,6 +3,7 @@
   "Description": "Go language support (gofmt and goimports)",
   "Tags": ["go", "golang"],
   "Website": "https://github.com/micro-editor/go-plugin",
+  "License": "MIT",
   "Versions": [
     {
       "Version": "2.0.2",

--- a/plugins/jlabbrev.json
+++ b/plugins/jlabbrev.json
@@ -3,6 +3,7 @@
 	"Description": "Julia backslash abbreviations in micro",
 	"Website": "https://github.com/MasFlam/jlabbrev",
 	"Tags": ["julia", "util"],
+    "License": "MIT",
 	"Versions": [{
 		"Version": "1.0.1",
 		"Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/jlabbrev-1.0.1.zip",

--- a/plugins/jlabbrev.json
+++ b/plugins/jlabbrev.json
@@ -1,0 +1,13 @@
+[{
+	"Name": "jlabbrev",
+	"Description": "Julia backslash abbreviations in micro",
+	"Website": "https://github.com/MasFlam/jlabbrev",
+	"Tags": ["julia", "util"],
+	"Versions": [{
+		"Version": "1.0.1",
+		"Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/jlabbrev-1.0.1.zip",
+		"Require": {
+			"micro": ">=2.0"
+		}
+	}]
+}]

--- a/plugins/join-lines-plugin.json
+++ b/plugins/join-lines-plugin.json
@@ -1,0 +1,14 @@
+[{
+  "Name": "joinLines",
+  "Description": "Plugin to join selected lines or join the following line with the current one",
+  "Tags": ["join lines"],
+  "Versions": [
+    {
+      "Version": "1.1.6",
+      "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/join-lines-plugin-1.1.6.zip",
+      "Require": {
+        "micro": ">=2.0.4"
+      }
+    }
+  ]
+}]

--- a/plugins/join-lines-plugin.json
+++ b/plugins/join-lines-plugin.json
@@ -2,6 +2,7 @@
   "Name": "joinLines",
   "Description": "Plugin to join selected lines or join the following line with the current one",
   "Tags": ["join lines"],
+  "Website": "https://github.com/Lisiadito/join-lines-plugin",
   "Versions": [
     {
       "Version": "1.1.6",

--- a/plugins/micro-aspell-plugin.json
+++ b/plugins/micro-aspell-plugin.json
@@ -1,0 +1,23 @@
+[{
+  "Name": "aspell",
+  "Description": "Spellchecking with Aspell",
+  "Tags": ["spellchecking", "spelling", "aspell", "spellchecker"],
+  "Website": "https://github.com/priner/micro-aspell-plugin",
+  "Versions": [
+    {
+      "Version": "1.3.0",
+      "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/micro-aspell-plugin-1.3.0.zip",
+      "Require": {
+        "micro": ">=2.0.7"
+      }
+    },
+    {
+      "Version": "1.2.0",
+      "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/micro-aspell-plugin-1.2.0.zip",
+      "Require": {
+        "micro": ">=2.0.0"
+      }
+    }
+  ]
+}]
+

--- a/plugins/micro-aspell-plugin.json
+++ b/plugins/micro-aspell-plugin.json
@@ -3,6 +3,7 @@
   "Description": "Spellchecking with Aspell",
   "Tags": ["spellchecking", "spelling", "aspell", "spellchecker"],
   "Website": "https://github.com/priner/micro-aspell-plugin",
+  "License": "MIT",
   "Versions": [
     {
       "Version": "1.3.0",

--- a/plugins/micro-autofmt.json
+++ b/plugins/micro-autofmt.json
@@ -1,0 +1,14 @@
+[{
+  "Name": "autofmt",
+  "Description": "plugin to run formatters on save",
+  "Tags": ["formatter"],
+  "Versions": [
+    {
+      "Version": "1.0.0",
+      "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/micro-autofmt-1.0.0.zip",
+      "Require": {
+        "micro": ">=2.0.8"
+      }
+    }
+  ]
+}]

--- a/plugins/micro-autofmt.json
+++ b/plugins/micro-autofmt.json
@@ -2,6 +2,7 @@
   "Name": "autofmt",
   "Description": "plugin to run formatters on save",
   "Tags": ["formatter"],
+  "Website": "https://github.com/a11ce/micro-autofmt",
   "Versions": [
     {
       "Version": "1.0.0",

--- a/plugins/micro-bookmark.json
+++ b/plugins/micro-bookmark.json
@@ -1,0 +1,16 @@
+[{
+  "Name": "bookmark",
+  "Description": "Bookmark lines to quickly jump between saved positions",
+  "Tags": ["bookmark"],
+  "Website": "https://github.com/haqk/micro-bookmark",
+  "Versions": [
+    {
+      "Version": "2.2.3",
+      "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/micro-bookmark-2.2.1.zip",
+      "Require": {
+        "micro": ">=2.0.0"
+      }
+    }
+  ]
+}]
+

--- a/plugins/micro-bookmark.json
+++ b/plugins/micro-bookmark.json
@@ -5,12 +5,53 @@
   "Website": "https://github.com/haqk/micro-bookmark",
   "Versions": [
     {
+      "Version": "2.2.4",
+      "Url": "https://github.com/haqk/micro-bookmark/archive/v2.2.4.zip",
+      "Require": {
+        "micro": ">=2.0.0"
+      }
+    },
+    {
       "Version": "2.2.3",
-      "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/micro-bookmark-2.2.1.zip",
+      "Url": "https://github.com/haqk/micro-bookmark/archive/v2.2.3.zip",
+      "Require": {
+        "micro": ">=2.0.0"
+      }
+    },
+    {
+      "Version": "2.2.2",
+      "Url": "https://github.com/haqk/micro-bookmark/archive/v2.2.2.zip",
+      "Require": {
+        "micro": ">=2.0.0"
+      }
+    },
+    {
+      "Version": "2.2.1",
+      "Url": "https://github.com/haqk/micro-bookmark/archive/v2.2.1.zip",
+      "Require": {
+        "micro": ">=2.0.0"
+      }
+    },
+    {
+      "Version": "2.2.0",
+      "Url": "https://github.com/haqk/micro-bookmark/archive/v2.2.0.zip",
+      "Require": {
+        "micro": ">=2.0.0"
+      }
+    },
+    {
+      "Version": "2.1.1",
+      "Url": "https://github.com/haqk/micro-bookmark/archive/v2.1.1.zip",
+      "Require": {
+        "micro": ">=2.0.0"
+      }
+    },
+    {
+      "Version": "2.0.0",
+      "Url": "https://github.com/haqk/micro-bookmark/archive/v2.0.0.zip",
       "Require": {
         "micro": ">=2.0.0"
       }
     }
   ]
 }]
-

--- a/plugins/micro-bookmark.json
+++ b/plugins/micro-bookmark.json
@@ -6,8 +6,8 @@
   "License": "MIT",
   "Versions": [
     {
-      "Version": "2.3.11",
-      "Url": "https://github.com/haqk/micro-bookmark/archive/v2.3.11.zip",
+      "Version": "2.5.0",
+      "Url": "https://github.com/haqk/micro-bookmark/archive/v2.5.0.zip",
       "Require": {
         "micro": ">=2.0.0"
       }

--- a/plugins/micro-bookmark.json
+++ b/plugins/micro-bookmark.json
@@ -6,8 +6,8 @@
   "License": "MIT",
   "Versions": [
     {
-      "Version": "2.3.10",
-      "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/micro-bookmark-2.3.10.zip",
+      "Version": "2.3.11",
+      "Url": "https://github.com/haqk/micro-bookmark/archive/v2.3.11.zip",
       "Require": {
         "micro": ">=2.0.0"
       }

--- a/plugins/micro-bookmark.json
+++ b/plugins/micro-bookmark.json
@@ -3,52 +3,11 @@
   "Description": "Bookmark lines to quickly jump between saved positions",
   "Tags": ["bookmark"],
   "Website": "https://github.com/haqk/micro-bookmark",
+  "License": "MIT",
   "Versions": [
     {
-      "Version": "2.2.4",
-      "Url": "https://github.com/haqk/micro-bookmark/archive/v2.2.4.zip",
-      "Require": {
-        "micro": ">=2.0.0"
-      }
-    },
-    {
-      "Version": "2.2.3",
-      "Url": "https://github.com/haqk/micro-bookmark/archive/v2.2.3.zip",
-      "Require": {
-        "micro": ">=2.0.0"
-      }
-    },
-    {
-      "Version": "2.2.2",
-      "Url": "https://github.com/haqk/micro-bookmark/archive/v2.2.2.zip",
-      "Require": {
-        "micro": ">=2.0.0"
-      }
-    },
-    {
-      "Version": "2.2.1",
-      "Url": "https://github.com/haqk/micro-bookmark/archive/v2.2.1.zip",
-      "Require": {
-        "micro": ">=2.0.0"
-      }
-    },
-    {
-      "Version": "2.2.0",
-      "Url": "https://github.com/haqk/micro-bookmark/archive/v2.2.0.zip",
-      "Require": {
-        "micro": ">=2.0.0"
-      }
-    },
-    {
-      "Version": "2.1.1",
-      "Url": "https://github.com/haqk/micro-bookmark/archive/v2.1.1.zip",
-      "Require": {
-        "micro": ">=2.0.0"
-      }
-    },
-    {
-      "Version": "2.0.0",
-      "Url": "https://github.com/haqk/micro-bookmark/archive/v2.0.0.zip",
+      "Version": "2.3.10",
+      "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/micro-bookmark-2.3.10.zip",
       "Require": {
         "micro": ">=2.0.0"
       }

--- a/plugins/micro-bounce.json
+++ b/plugins/micro-bounce.json
@@ -2,6 +2,7 @@
   "Name": "bounce",
   "Description": "plugin to add nano-style 'smart home' and bounce cursor between matching brackets",
   "Tags": ["bounce", "smarthome"],
+  "Website": "https://github.com/deusnefum/micro-bounce",
   "Versions": [
     {
       "Version": "1.1.2",

--- a/plugins/micro-bounce.json
+++ b/plugins/micro-bounce.json
@@ -1,0 +1,14 @@
+[{
+  "Name": "bounce",
+  "Description": "plugin to add nano-style 'smart home' and bounce cursor between matching brackets",
+  "Tags": ["bounce", "smarthome"],
+  "Versions": [
+    {
+      "Version": "1.1.2",
+      "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/micro-bounce-1.1.2.zip",
+      "Require": {
+        "micro": ">=2.0.0"
+      }
+    }
+  ]
+}]

--- a/plugins/micro-detectindent.json
+++ b/plugins/micro-detectindent.json
@@ -1,0 +1,16 @@
+[{
+  "Name": "detectindent",
+  "Description": "Automatically detect indentation settings",
+  "Tags": ["indent", "detect"],
+  "Website": "https://github.com/dmaluka/micro-detectindent",
+  "Versions": [
+    {
+      "Version": "1.1.0",
+      "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/micro-detectindent-1.1.0.zip",
+      "Require": {
+        "micro": ">=2.0.0"
+      }
+    }
+  ]
+}]
+

--- a/plugins/micro-gotham-colors.json
+++ b/plugins/micro-gotham-colors.json
@@ -1,0 +1,25 @@
+[
+    {
+        "Name": "gotham-colors",
+        "Description": "A very dark colorscheme",
+        "Tags": [
+            "gotham",
+            "colors",
+            "color",
+            "themes",
+            "theme",
+            "colorschemes",
+            "colorscheme",
+            "dark"
+        ],
+        "Versions": [
+            {
+                "Version": "1.1.0",
+                "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/micro-gotham-colors-1.1.0.zip",
+                "Require": {
+                    "micro": ">=1.1.3"
+                }
+            }
+        ]
+    }
+]

--- a/plugins/micro-jump.json
+++ b/plugins/micro-jump.json
@@ -3,6 +3,7 @@
   "Description": "Jump to any function, class or heading with F4. Go, Markdown, Python, C...",
   "Website": "https://github.com/terokarvinen/micro-jump",
   "Tags": ["ctags", "fzf", "symbols", "code browser", "jump"],
+  "License": "MIT",
   "Versions": [
     {
       "Version": "0.0.5",

--- a/plugins/micro-jump.json
+++ b/plugins/micro-jump.json
@@ -1,0 +1,15 @@
+[{
+  "Name": "jump",
+  "Description": "Jump to any function, class or heading with F4. Go, Markdown, Python, C...",
+  "Website": "https://github.com/terokarvinen/micro-jump",
+  "Tags": ["ctags", "fzf", "symbols", "code browser", "jump"],
+  "Versions": [
+    {
+      "Version": "0.0.5",
+      "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/micro-jump-0.0.4.zip",
+      "Require": { 
+        "micro": ">=2.0.0"
+      }
+    }
+  ]
+}]

--- a/plugins/micro-monokai-dark.json
+++ b/plugins/micro-monokai-dark.json
@@ -1,0 +1,14 @@
+[{
+  "Name": "monokai-dark",
+  "Description": "A dark monokai colorscheme for micro",
+  "Tags": ["colorscheme"],
+  "Versions": [
+    {
+      "Version": "0.1.0",
+      "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/micro-monokai-dark-0.1.0.zip",
+      "Require": {
+        "micro": ">=1.1.3"
+      }
+    }
+  ]
+}]

--- a/plugins/micro-nord-tc-colors.json
+++ b/plugins/micro-nord-tc-colors.json
@@ -3,6 +3,7 @@
   "Description": "A color palette based on the Nord colorscheme",
   "Tags": ["nord", "color", "truecolor", "16"],
   "Website": "https://github.com/KiranWells/micro-nord-tc-colors/",
+  "License": "MIT",
   "Versions": [
     {
       "Version": "1.1.4",

--- a/plugins/micro-nord-tc-colors.json
+++ b/plugins/micro-nord-tc-colors.json
@@ -1,0 +1,15 @@
+[{
+  "Name": "nordcolors",
+  "Description": "A color palette based on the Nord colorscheme",
+  "Tags": ["nord", "color", "truecolor", "16"],
+  "Website": "https://github.com/KiranWells/micro-nord-tc-colors/",
+  "Versions": [
+    {
+      "Version": "1.1.4",
+      "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/micro-nord-tc-colors-1.1.4.zip",
+      "Require": {
+        "micro": ">=1.1.3"
+      }
+    }
+  ]
+}]

--- a/plugins/micro-plugin-lsp.json
+++ b/plugins/micro-plugin-lsp.json
@@ -1,0 +1,79 @@
+[{
+  "Name": "lsp",
+  "Description": "Generic LSP Client for Micro",
+  "Website": "https://github.com/AndCake/micro-plugin-lsp",
+  "Tags": ["lsp"],
+  "Versions": [
+    {
+      "Version": "0.4.1",
+      "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/micro-plugin-lsp-0.4.1.zip",
+      "Require": {
+        "micro": ">=2.0.10"
+      }
+    },
+    {
+      "Version": "0.4.2",
+      "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/micro-plugin-lsp-0.4.2.zip",
+      "Require": {
+        "micro": ">=2.0.8"
+      }
+    },
+    {
+      "Version": "0.4.3",
+      "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/micro-plugin-lsp-0.4.3.zip",
+      "Require": {
+        "micro": ">=2.0.8"
+      }
+    },
+    {
+      "Version": "0.5.0",
+      "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/micro-plugin-lsp-0.5.0.zip",
+      "Require": {
+        "micro": ">=2.0.8"
+      }
+    },
+    {
+      "Version": "0.5.1",
+      "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/micro-plugin-lsp-0.5.1.zip",
+      "Require": {
+        "micro": ">=2.0.8"
+      }
+    },
+    {
+      "Version": "0.5.2",
+      "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/micro-plugin-lsp-0.5.2.zip",
+      "Require": {
+        "micro": ">=2.0.8"
+      }
+    },
+    {
+      "Version": "0.5.3",
+      "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/micro-plugin-lsp-0.5.3.zip",
+      "Require": {
+        "micro": ">=2.0.8"
+      }
+    },
+    {
+      "Version": "0.6.0",
+      "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/micro-plugin-lsp-0.6.0.zip",
+      "Require": {
+        "micro": ">=2.0.8"
+      }
+    },
+    {
+      "Version": "0.6.1",
+      "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/micro-plugin-lsp-0.6.1.zip",
+      "Require": {
+        "micro": ">=2.0.8"
+      }
+    },
+    {
+      "Version": "0.6.2",
+      "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/micro-plugin-lsp-0.6.2.zip",
+      "Require": {
+        "micro": ">=2.0.8"
+      }
+    }
+  ]
+}]
+

--- a/plugins/micro-plugin-lsp.json
+++ b/plugins/micro-plugin-lsp.json
@@ -3,6 +3,7 @@
   "Description": "Generic LSP Client for Micro",
   "Website": "https://github.com/AndCake/micro-plugin-lsp",
   "Tags": ["lsp"],
+  "License": "MIT",
   "Versions": [
     {
       "Version": "0.4.1",

--- a/plugins/micro-quickfix.json
+++ b/plugins/micro-quickfix.json
@@ -3,6 +3,7 @@
   "Description": "Plugin to speedup the edit-make-edit development cycle.",
   "Tags": ["quickfix"],
   "Website": "https://github.com/serge-v/micro-quickfix",
+  "License": "MIT",
   "Versions": [
     {
       "Version": "2.1.2",

--- a/plugins/micro-quickfix.json
+++ b/plugins/micro-quickfix.json
@@ -1,0 +1,15 @@
+[{
+  "Name": "quickfix",
+  "Description": "Plugin to speedup the edit-make-edit development cycle.",
+  "Tags": ["quickfix"],
+  "Website": "https://github.com/serge-v/micro-quickfix",
+  "Versions": [
+    {
+      "Version": "2.1.2",
+      "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/micro-quickfix-2.1.2.zip",
+      "Require": {
+        "micro": ">=2.0.0"
+      }
+    }
+  ]
+}]

--- a/plugins/micro-quoter.json
+++ b/plugins/micro-quoter.json
@@ -1,0 +1,19 @@
+[
+  {
+    "Name": "quoter",
+    "Description": "plugin to add quotes or brackets around a text selection.",
+    "Tags": [
+      "quote", "autosurround"
+    ],
+    "Versions": [
+      
+      {
+        "Version": "1.0.2",
+        "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/micro-quoter-1.0.2.zip",
+        "Require": {
+          "micro": ">=2.0.0"
+        }
+      }
+    ]
+  }
+]

--- a/plugins/micro-quoter.json
+++ b/plugins/micro-quoter.json
@@ -5,6 +5,7 @@
     "Tags": [
       "quote", "autosurround"
     ],
+    "Website": "https://github.com/sparques/micro-quoter",
     "Versions": [
       
       {

--- a/plugins/micro-scratch-plugin.json
+++ b/plugins/micro-scratch-plugin.json
@@ -1,0 +1,16 @@
+[
+	{
+		"Name": "scratch",
+		"Description": "gives access to a function to create temporary buffers",
+		"Tags": ["scratch"],
+		"Versions": [
+			{
+				"Version": "1.0.0",
+				"Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/micro-scratch-plugin-1.0.0.zip",
+				"Require": {
+					"micro": ">=1.1.2"
+				}
+			}
+		]
+	}
+]

--- a/plugins/micro-wakatime.json
+++ b/plugins/micro-wakatime.json
@@ -1,0 +1,16 @@
+[{
+    "Name": "wakatime",
+    "Description": "Metrics, insights, and time tracking automatically generated from your programming activity",
+    "Website": "https://github.com/wakatime/micro-wakatime",
+    "Tags": ["productivity", "time tracking", "project", "git", "timer"],
+    "Versions": [
+      {
+        "Version": "1.0.5",
+        "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/micro-wakatime-1.0.5.zip",
+        "Require": {
+          "micro": ">=2.0.0"
+        }
+      }
+    ]
+}]
+

--- a/plugins/micro-zigfmt.json
+++ b/plugins/micro-zigfmt.json
@@ -3,6 +3,7 @@
   "Description": "zig fmt on save and zig fmt --check linter support",
   "Tags": ["zig", "ziglang"],
   "Website": "https://github.com/squeek502/micro-zigfmt",
+  "License": "Unlicense",
   "Versions": [
     {
       "Version": "0.1.1",

--- a/plugins/micro-zigfmt.json
+++ b/plugins/micro-zigfmt.json
@@ -1,0 +1,15 @@
+[{
+  "Name": "zigfmt",
+  "Description": "zig fmt on save and zig fmt --check linter support",
+  "Tags": ["zig", "ziglang"],
+  "Website": "https://github.com/squeek502/micro-zigfmt",
+  "Versions": [
+    {
+      "Version": "0.1.1",
+      "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/micro-zigfmt-0.1.1.zip",
+      "Require": {
+        "micro": ">=2.0.0"
+      }
+    }
+  ]
+}]


### PR DESCRIPTION
Updates the `bookmark` plugin manifest to **v2.5.0**.

- Single latest `Versions` entry pointing at the repo tag archive (live now): https://github.com/haqk/micro-bookmark/archive/v2.5.0.zip
- Requires `micro >= 2.0.0`.

The channel currently ships an old build, so `micro -plugin install bookmark` is several releases behind. v2.5.0 adds content-anchored persistence (bookmarks survive edits made while a file is closed), fixes persistence on quit and for command-line-opened files, and adds select-between-bookmarks commands. Changelog: https://github.com/haqk/micro-bookmark/blob/main/CHANGELOG.md

Maintained at https://github.com/haqk/micro-bookmark