### PR TITLE
adding repfiles plugin

### DIFF
--- a/channel.json
+++ b/channel.json
@@ -78,5 +78,8 @@
   "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-detectindent.json",
 
   // lsp plugin
-  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-plugin-lsp.json"
+  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-plugin-lsp.json",
+
+  //repfiles plugin
+  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/repfiles.json"
 ]

--- a/plugins/repfiles.json
+++ b/plugins/repfiles.json
@@ -1,0 +1,16 @@
+[{
+  "Name": "repfiles",
+  "Description": "a filemanager for your repository",
+  "Tags": ["filemanager", "git", "repository"],
+  "Website": "https://github.com/gaenseklein/repfiles",
+  "License": "GPL3",
+  "Versions": [    
+    {
+      "Version": "1.0.0",
+      "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/repfiles-1.0.0.zip",
+      "Require": {
+        "micro": ">=2.0.10"
+      }
+    }
+  ]
+}]


### PR DESCRIPTION
This is a

* [x] New plugin.
* [ ] Update to an existing plugin.

Plugin name and version:  repfiles v1.0.0

Plugin source code zip file: [https://github.com/gaenseklein/repfiles/archive/refs/tags/v1.0.0.zip](https://github.com/gaenseklein/repfiles/archive/refs/tags/v1.0.0.zip)

Checklist:

* [x] Plugin has a repo.json listing the `Name`, `Description`, `Website`, and `License`.
* [x] I have read the instructions at https://github.com/micro-editor/plugin-channel#adding-your-own-plugin.

---
plugin repo is 
https://github.com/gaenseklein/repfiles

glad to share it. makes fun to work with. no mouse-support as i cant get the mouse-events to work in lua plugins (filemanagers mouse-support also does not work)