### PR TITLE
Add `manager` plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `jump`      | Jump to any function, class or heading with F4. Go, Markdown, Python, C and in 40 other languages | https://github.com/terokarvinen/micro-jump   | :heavy_check_mark:      |
 | `detectindent`  | Automatically detect indentation settings               | https://github.com/dmaluka/micro-detectindent              | :heavy_check_mark:                       |
 | `lsp`           | An basic LSP client implementation                      | https://github.com/AndCake/micro-plugin-lsp                | :heavy_check_mark:                       |
+| `manager`           | The plugin manager provides a way to manage linters, formatters, commands, keybindings, settings, plugins | https://codeberg.org/micro-plugins/manager                | :heavy_check_mark:                       |
 
 
 ## Adding your own plugin

--- a/channel.json
+++ b/channel.json
@@ -1,4 +1,7 @@
 [
+  // manager plugin
+  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/manager.json",
+
   // EditorConfig plugin
   "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/editorconfig-micro.json",
 

--- a/plugins/manager.json
+++ b/plugins/manager.json
@@ -1,0 +1,166 @@
+[
+    {
+        "Description": "The plugin manager provides a way to manage linters, formatters, commands, keybindings, settings, plugins.",
+        "License": "GPL-3.0-or-later",
+        "Name": "manager",
+        "Tags": [
+            "keybindings",
+            "bind",
+            "bindings",
+            "cmd",
+            "codestyle",
+            "command",
+            "commands",
+            "config",
+            "fmt",
+            "format",
+            "formatter",
+            "formatters",
+            "formatting",
+            "init.lua",
+            "lint",
+            "linter",
+            "linters",
+            "linting",
+            "lua",
+            "micro",
+            "micro-editor",
+            "micro-plugin",
+            "onSave",
+            "plug",
+            "plugin",
+            "plugins",
+            "settings",
+            "settings.json"
+        ],
+        "Versions": [
+            {
+                "Require": {
+                    "micro": ">=2.0.13"
+                },
+                "Url": "https://codeberg.org/micro-plugins/manager/archive/v3.3.0.zip",
+                "Version": "3.3.0"
+            },
+            {
+                "Require": {
+                    "micro": ">=2.0.13"
+                },
+                "Url": "https://codeberg.org/micro-plugins/manager/archive/v3.2.4.zip",
+                "Version": "3.2.4"
+            },
+            {
+                "Require": {
+                    "micro": ">=2.0.13"
+                },
+                "Url": "https://codeberg.org/micro-plugins/manager/archive/v3.2.3.zip",
+                "Version": "3.2.3"
+            },
+            {
+                "Require": {
+                    "micro": ">=2.0.13"
+                },
+                "Url": "https://codeberg.org/micro-plugins/manager/archive/v3.2.2.zip",
+                "Version": "3.2.2"
+            },
+            {
+                "Require": {
+                    "micro": ">=2.0.13"
+                },
+                "Url": "https://codeberg.org/micro-plugins/manager/archive/v3.2.1.zip",
+                "Version": "3.2.1"
+            },
+            {
+                "Require": {
+                    "micro": ">=2.0.13"
+                },
+                "Url": "https://codeberg.org/micro-plugins/manager/archive/v3.2.0.zip",
+                "Version": "3.2.0"
+            },
+            {
+                "Require": {
+                    "micro": ">=2.0.13"
+                },
+                "Url": "https://codeberg.org/micro-plugins/manager/archive/v3.1.0.zip",
+                "Version": "3.1.0"
+            },
+            {
+                "Require": {
+                    "micro": ">=2.0.12"
+                },
+                "Url": "https://codeberg.org/micro-plugins/manager/archive/v3.0.0.zip",
+                "Version": "3.0.0"
+            },
+            {
+                "Require": {
+                    "micro": ">=2.0.12"
+                },
+                "Url": "https://codeberg.org/micro-plugins/manager/archive/v2.1.1.zip",
+                "Version": "2.1.1"
+            },
+            {
+                "Require": {
+                    "micro": ">=2.0.11"
+                },
+                "Url": "https://codeberg.org/micro-plugins/manager/archive/v2.1.0.zip",
+                "Version": "2.1.0"
+            },
+            {
+                "Require": {
+                    "micro": ">=2.0.11"
+                },
+                "Url": "https://codeberg.org/micro-plugins/manager/archive/v2.0.4.zip",
+                "Version": "2.0.4"
+            },
+            {
+                "Require": {
+                    "micro": ">=2.0.11"
+                },
+                "Url": "https://codeberg.org/micro-plugins/manager/archive/v2.0.3.zip",
+                "Version": "2.0.3"
+            },
+            {
+                "Require": {
+                    "micro": ">=2.0.11"
+                },
+                "Url": "https://codeberg.org/micro-plugins/manager/archive/v2.0.2.zip",
+                "Version": "2.0.2"
+            },
+            {
+                "Require": {
+                    "micro": ">=2.0.11"
+                },
+                "Url": "https://codeberg.org/micro-plugins/manager/archive/v2.0.1.zip",
+                "Version": "2.0.1"
+            },
+            {
+                "Require": {
+                    "micro": ">=2.0.11"
+                },
+                "Url": "https://codeberg.org/micro-plugins/manager/archive/v2.0.0.zip",
+                "Version": "2.0.0"
+            },
+            {
+                "Require": {
+                    "micro": ">=2.0.11"
+                },
+                "Url": "https://codeberg.org/micro-plugins/manager/archive/v1.0.0.zip",
+                "Version": "1.0.0"
+            },
+            {
+                "Require": {
+                    "micro": ">=2.0.11"
+                },
+                "Url": "https://codeberg.org/micro-plugins/manager/archive/v0.1.1.zip",
+                "Version": "0.1.1"
+            },
+            {
+                "Require": {
+                    "micro": ">=2.0.11"
+                },
+                "Url": "https://codeberg.org/micro-plugins/manager/archive/v0.1.0.zip",
+                "Version": "0.1.0"
+            }
+        ],
+        "Website": "https://manager.readthedocs.io"
+    }
+]


### PR DESCRIPTION
This is a

* [x] New plugin.
* [ ] Update to an existing plugin.

Plugin name and version: manager 3.3.0

Plugin source code zip file: https://codeberg.org/micro-plugins/manager/archive/v3.3.0.zip.

<!-- In your PR, please list the zip file link as if it has been uploaded to https://github.com/micro-editor/plugin-channel/releases/tag/plugins. -->
<!-- If your plugin is approved, it will be uploaded there when merging the PR. -->

Checklist:

* [x] Plugin has a repo.json listing the `Name`, `Description`, `Website`, and `License`.
* [x] I have read the instructions at https://github.com/micro-editor/plugin-channel#adding-your-own-plugin.

---

<!-- Other comments here -->

The plugin manager provides a way to manage linters, formatters, commands, keybindings, settings, plugins.

Below is an example of use, for more details see the [documentation](https://manager.readthedocs.io/) or open an [issue](https://codeberg.org/micro-plugins/manager/issues) for questions, suggestions or bug reports.
## Dashboard

Inspired by [telescope.nvim], [project.nvim], [alpha-nvim] and the lunarvim dashboard
we have a dash to manage your projects and files.

Open the dashboard with the command `> manager dash` or with the default bind `Alt-Ctrl-o`.

![dashboard](https://codeberg.org/micro-plugins/manager/raw/branch/main/docs/assets/dashboard.png)

For more details see the [dashboard documentation].

## Info Buffer

A buffer with the configuration status can be viewed with the `manager info` command
or with the default bind `Alt-Ctrl-q`.

![infopane](https://codeberg.org/micro-plugins/manager/raw/branch/main/docs/assets/infopane.png)

Use arrows to navigate statuses.

## An example `~/.config/micro/init.lua`

```lua title="~/.config/micro/init.lua"
linters = {  -- (1)!
  {
    cmd = 'tsc --noEmit --pretty false %f',
    errorformat = '%f%(%l,%c%): %m',
    filetypes = { 'typescript' },
  },
}

formatters = {  -- (2)!
  {
    cmd = 'isort -l 79 --trailing-comma --multi-line 3 %f',
    name = 'isort',  -- command name: `> isort`
    bind = 'Alt-g',
    onSave = true,
    filetypes = { 'python' },
  },
}

bindings = {  -- (3)!
  { key = 'Alt-m', cmd = 'JumpToMatchingBrace', overwrite = true },
}

settings = {  -- (4)!
  ['ft:json'] = { commenttype = '// %s' },
  colorscheme = 'one-dark',
  pluginrepos = { 'https://codeberg.org/micro-plugins/manager/raw/branch/main/repo.json' },
  tabstospaces = true,
}

plugins = {  -- (5)!
  {
    'lsp',
    git = { url = 'https://github.com/AndCake/micro-plugin-lsp.git', branch = 'main' },
    config = {
      ['lsp.formatOnSave'] = false,
    },
    bindings = {
      { key = 'CtrlSpace', cmd = 'command:lspcompletion', overwrite = true },
    },
  },
}

commands = {  -- (6)!
  {
    -- Open a new Vsplit (on the very left)
    name = { 'vsp',  'vsplitleft' },
    action = function(bp)
      local micro = import('micro')
      local buffer = import('micro/buffer')

      bp:VSplitIndex(buffer.NewBuffer('', ''), false) -- right=false
      micro.InfoBar():Message('New open file')
    end,
    bindings = {
      { key = 'Alt-|', cmd = 'command:vsp', overwrite = true },
    },
    complete = config.NoComplete,
  },
}
```

1. For more details see the linters [documentation](https://manager.readthedocs.io/linters/).
2. For more details see the formatter [documentation](https://manager.readthedocs.io/formatters).
3. For more details see the binding [documentation](https://manager.readthedocs.io/bindings).
4. For more details see the settings [documentation](https://manager.readthedocs.io/settings).
5. For more details see the plugin [documentation](https://manager.readthedocs.io/plugins).
6. For more details see the command [documentation](https://manager.readthedocs.io/commands).

[dashboard documentation]: https://manager.readthedocs.io/dashboard
[telescope.nvim]: https://github.com/nvim-telescope/telescope.nvim
[project.nvim]: https://github.com/ahmedkhalf/project.nvim
[alpha-nvim]: https://github.com/goolord/alpha-nvim