### PR TITLE
adding battery plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `jump`      | Jump to any function, class or heading with F4. Go, Markdown, Python, C and in 40 other languages | https://github.com/terokarvinen/micro-jump   | :heavy_check_mark:      |
 | `detectindent`  | Automatically detect indentation settings               | https://github.com/dmaluka/micro-detectindent              | :heavy_check_mark:                       |
 | `lsp`           | An basic LSP client implementation                      | https://github.com/AndCake/micro-plugin-lsp                | :heavy_check_mark:                       |
+| `battery`           | Displays battery percentage on the infobar          | https://github.com/dubyte/micro-battery                    | :heavy_check_mark:                       |
 
 
 ## Adding your own plugin

--- a/channel.json
+++ b/channel.json
@@ -78,5 +78,8 @@
   "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-detectindent.json",
 
   // lsp plugin
-  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-plugin-lsp.json"
+  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-plugin-lsp.json",
+
+  // battery plugin
+  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-battery.json"
 ]

--- a/plugins/micro-battery.json
+++ b/plugins/micro-battery.json
@@ -1,0 +1,16 @@
+[{
+    "Name": "battery",
+    "Description": "Battery displays battery percentage",
+    "Tags": ["battery", "laptop"],
+    "Website": "https://github.com/dubyte/micro-dubyte",
+    "License": "MIT",
+    "Versions": [
+      {
+        "Version": "0.0.1",
+        "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/micro-battery-0.0.1.zip",
+        "Require": {
+          "micro": ">=2.0.0"
+        }
+      }
+    ]
+  }]


### PR DESCRIPTION
This is a

* [x] New plugin.
* [ ] Update to an existing plugin.

Plugin name and version: 
- battery  v0.0.1
Plugin source code zip file: (please upload a zip file or link a zip file).

Checklist:

* [x] Plugin has a repo.json listing the `Name`, `Description`, `Website`, and `License`.
* [x] I have read the instructions at https://github.com/micro-editor/plugin-channel#adding-your-own-plugin.

---
[micro-battery-0.0.1.zip](https://github.com/micro-editor/plugin-channel/files/13643104/micro-battery-0.0.1.zip)

It depends on upower