### PR TITLE
Update micro-quoter to v1.0.3

### DIFF
--- a/plugins/micro-quoter.json
+++ b/plugins/micro-quoter.json
@@ -7,7 +7,12 @@
     ],
     "Website": "https://github.com/sparques/micro-quoter",
     "Versions": [
-      
+      {
+        "Version": "1.0.3",
+        "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/micro-quoter-1.0.3.zip",
+        "Require": {
+          "micro": ">=2.0.0"
+        },
       {
         "Version": "1.0.2",
         "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/micro-quoter-1.0.2.zip",


### PR DESCRIPTION
This is a

* [ ] New plugin.
* ✅ Update to an existing plugin.

Plugin name and version: micro-quoter v1.0.3

Plugin source code zip file: https://github.com/sparques/micro-quoter/archive/refs/tags/v1.0.3.zip

<!-- In your PR, please list the zip file link as if it has been uploaded to https://github.com/micro-editor/plugin-channel/releases/tag/plugins. -->
<!-- If your plugin is approved, it will be uploaded there when merging the PR. -->

Checklist:

* ✅ Plugin has a repo.json listing the `Name`, `Description`, `Website`, and `License`.
* ✅ I have read the instructions at https://github.com/micro-editor/plugin-channel#adding-your-own-plugin.

---
