### PR TITLE
Add micro-run, palettero and micro-cheat plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `jump`      | Jump to any function, class or heading with F4. Go, Markdown, Python, C and in 40 other languages | https://github.com/terokarvinen/micro-jump   | :heavy_check_mark:      |
 | `detectindent`  | Automatically detect indentation settings               | https://github.com/dmaluka/micro-detectindent              | :heavy_check_mark:                       |
 | `lsp`           | An basic LSP client implementation                      | https://github.com/AndCake/micro-plugin-lsp                | :heavy_check_mark:                       |
-
+| `run`      | F5 to save and run, F12 to 'make', F9 to 'make' in background. Go, Python, Lua and executable file (#!) supported. Can 'make' whole project even from subdir. | https://github.com/terokarvinen/micro-run   | :heavy_check_mark:      |
+| `palettero`      | Command palette - Ctrl-P to fuzzy search & run commands, textfilters and descriptions. Use Python oneliners and grep to edit text. |  https://github.com/terokarvinen/palettero  | :heavy_check_mark:      |
+| `cheat`      | F1 cheatsheet for the language you're editing: Python, Go, Lua... |  https://github.com/terokarvinen/micro-cheat  | :heavy_check_mark:      |
 
 ## Adding your own plugin
 

--- a/channel.json
+++ b/channel.json
@@ -78,5 +78,15 @@
   "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-detectindent.json",
 
   // lsp plugin
-  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-plugin-lsp.json"
+  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-plugin-lsp.json",
+
+  // run plugin
+  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-run.json",
+
+  // palettero plugin
+  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/palettero.json",
+
+  // cheat plugin
+  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-cheat.json"
+
 ]

--- a/plugins/micro-cheat.json
+++ b/plugins/micro-cheat.json
@@ -1,0 +1,36 @@
+[{
+  "Name": "cheat",
+  "Description": "F1 for cheatsheet related to the type of file you're editing: Lua, Go, Python...",
+  "Website": "https://terokarvinen.com/micro",
+  "Tags": ["cheatsheet", "help", "docs", "Lua", "Go", "Python", "reference"],
+  "License": "MIT license",
+  "Versions": [
+    {
+      "Version": "0.0.4",
+      "Url": "https://github.com/terokarvinen/micro-cheat/archive/v0.0.4.zip",
+      "Require": {
+        "micro": ">=2.0.0"
+      }
+    },
+    {
+      "Version": "0.0.3",
+      "Url": "https://github.com/terokarvinen/micro-cheat/archive/v0.0.3.zip",
+      "Require": {
+        "micro": ">=2.0.0"
+      }
+    },
+    {
+      "Version": "0.0.2",
+      "Url": "https://github.com/terokarvinen/micro-cheat/archive/v0.0.2.zip",
+      "Require": {
+        "micro": ">=2.0.0"
+      }
+    },
+    {
+      "Version": "0.0.1",
+      "Require": {
+        "micro": ">=2.0.0"
+      }
+    }
+  ]
+}]

--- a/plugins/micro-run.json
+++ b/plugins/micro-run.json
@@ -1,0 +1,44 @@
+[{
+  "Name": "runit",
+  "Description": "Press F5 to save and run, F12 to make, F9 to make in background.",
+  "Website": "https://github.com/terokarvinen/micro-run",
+  "Tags": ["run", "execute", "Go", "Python", "Bash", "Lua", "F5"],
+  "License": "MIT license",
+  "Versions": [
+    {
+      "Version": "0.0.8",
+      "Url": "https://github.com/terokarvinen/micro-run/archive/v0.0.8.zip",
+      "Require": {
+        "micro": ">=2.0.0"
+      }
+    },
+    {
+      "Version": "0.0.7",
+      "Url": "https://github.com/terokarvinen/micro-run/archive/v0.0.7.zip",
+      "Require": {
+        "micro": ">=2.0.0"
+      }
+    },
+    {
+      "Version": "0.0.6",
+      "Url": "https://github.com/terokarvinen/micro-run/archive/v0.0.6.zip",
+      "Require": {
+        "micro": ">=2.0.0"
+      }
+    },
+    {
+      "Version": "0.0.5",
+      "Url": "https://github.com/terokarvinen/micro-run/archive/v0.0.5.zip",
+      "Require": {
+        "micro": ">=2.0.0"
+      }
+    },
+    {
+      "Version": "0.0.4",
+      "Url": "https://github.com/terokarvinen/micro-run/archive/v0.0.4.zip",
+      "Require": {
+        "micro": ">=2.0.0"
+      }
+    }
+  ]
+}]

--- a/plugins/palettero.json
+++ b/plugins/palettero.json
@@ -1,0 +1,30 @@
+[{
+  "Name": "palettero",
+  "Description": "Command palette Ctrl-P - fuzzy search commands and textfilters",
+  "Website": "https://terokarvinen.com/tags/micro-editor/",
+  "Tags": ["command palette", "fzf", "menu"],
+  "License": "GNU General Public License v3",
+  "Versions": [
+    {
+      "Version": "0.0.5",
+      "Url": "https://github.com/terokarvinen/palettero/archive/0.0.5.zip",
+      "Require": {
+        "micro": ">=2.0.0"
+      }
+    },
+    {
+      "Version": "0.0.4",
+      "Url": "https://github.com/terokarvinen/palettero/archive/v0.0.4.zip",
+      "Require": {
+        "micro": ">=2.0.0"
+      }
+    },
+    {
+      "Version": "0.0.2",
+      "Url": "https://github.com/terokarvinen/palettero/archive/v0.0.2.zip",
+      "Require": {
+        "micro": ">=2.0.0"
+      }
+    }
+  ]
+}]


### PR DESCRIPTION
This is a

* [x] New plugin.
* [ ] Update to an existing plugin.

Plugin name and version: Run 0.0.8, Palettero 0.0.5, Cheat 0.0.4

Plugin source code zip file: https://github.com/terokarvinen/micro-run/archive/refs/heads/main.zip https://github.com/terokarvinen/palettero/archive/refs/heads/main.zip https://github.com/terokarvinen/micro-cheat/archive/refs/heads/main.zip

Checklist:

* [x] Plugin has a repo.json listing the `Name`, `Description`, `Website`, and `License`.
* [x] I have read the instructions at https://github.com/micro-editor/plugin-channel#adding-your-own-plugin.

---

I recreated pull request #88 for these plugins from 2022. I have made all improvements requested by @taconi 5 days ago: 

* Conflicts resolved
* Added License field to each repo.json
* Added repo.json:s to plugins/ folder with plugin name as the file name

It's great to see new plugins coming to micro-editor. Thanks for your work, @taconi & @zyedidia!
