### PR TITLE
:star2: adds new version of lsp plugin

### DIFF
--- a/plugins/micro-plugin-lsp.json
+++ b/plugins/micro-plugin-lsp.json
@@ -74,6 +74,13 @@
       "Require": {
         "micro": ">=2.0.8"
       }
+    },
+    {
+      "Version": "0.6.3",
+      "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/micro-plugin-lsp-0.6.3.zip",
+      "Require": {
+        "micro": ">=2.0.8"
+      }
     }
   ]
 }]


### PR DESCRIPTION
This is a

* [ ] New plugin.
* [x] Update to an existing plugin.

Plugin name and version: micro-plugin-lsp, 0.6.3

Plugin source code zip file: https://github.com/AndCake/micro-plugin-lsp/archive/refs/tags/v0.6.3.zip


<!-- In your PR, please list the zip file link as if it has been uploaded to https://github.com/micro-editor/plugin-channel/releases/tag/plugins. -->
<!-- If your plugin is approved, it will be uploaded there when merging the PR. -->

Checklist:

* [x] Plugin has a repo.json listing the `Name`, `Description`, `Website`, and `License`.
* [x] I have read the instructions at https://github.com/micro-editor/plugin-channel#adding-your-own-plugin.

---

<!-- Other comments here -->
