### PR TITLE
Updating misspell plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `editorconfig`  | EditorConfig Support for micro                          | https://github.com/10sr/editorconfig-micro                 | :heavy_check_mark:                       |
 | `crystal`       | Provides various `crystal` tools for crystal files      | https://github.com/ColinRioux/micro-crystal                | :heavy_check_mark:                       |
 | `gotham-colors` | A colorscheme for code that never sleeps in Gotham City | https://github.com/novln/micro-gotham-colors               | :heavy_check_mark: (provided by default) |
-| `misspell`      | Plugin that corrects commonly misspelled words          | https://github.com/onodera-punpun/micro-misspell-plugin    | :heavy_check_mark:                       |
+| `misspell`      | Plugin that corrects commonly misspelled words          | https://github.com/onodera-punpun/micro-misspell-plugin (Original) <br> <br> https://github.com/Neko-Box-Coder/micro-misspell-plugin (Updated)  | :heavy_check_mark:               |
 | `monokai-dark`  | A dark monokai colorscheme                              | https://github.com/Theodus/micro-monokai-dark              | :heavy_check_mark: (provided by default) |
 | `manipulator`   | Extend text manipulation abilities                      | https://github.com/NicolaiSoeborg/manipulator-plugin       | :heavy_check_mark:                       |
 | `filemanager`   | A file manager!                                         | https://github.com/NicolaiSoeborg/filemanager-plugin       | :heavy_check_mark:                       |

--- a/channel.json
+++ b/channel.json
@@ -87,6 +87,8 @@
   "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/palettero.json",
 
   // cheat plugin
-  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-cheat.json"
+  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-cheat.json",
 
+  // misspell plugin
+  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-misspell.json"
 ]

--- a/plugins/micro-misspell.json
+++ b/plugins/micro-misspell.json
@@ -1,0 +1,14 @@
+[{
+  "Name": "misspell",
+  "Description": "plugin that corrects commonly misspelled words",
+  "Tags": ["spell", "check", "misspell"],
+  "Versions": [
+    {
+      "Version": "0.2.0",
+      "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/0.2.0.zip",
+      "Require": {
+        "micro": ">=2.0.0"
+      }
+    }
+  ]
+}]


### PR DESCRIPTION
This is a

* [ ] New plugin.
* [x] Update to an existing plugin.

Plugin name and version: misspell (v0.2.0)

Plugin source code zip file: 
https://github.com/Neko-Box-Coder/micro-misspell-plugin/archive/refs/tags/v0.2.0.zip

<!-- In your PR, please list the zip file link as if it has been uploaded to https://github.com/micro-editor/plugin-channel/releases/tag/plugins. -->
<!-- If your plugin is approved, it will be uploaded there when merging the PR. -->


Checklist:

* [x] Plugin has a repo.json listing the `Name`, `Description`, `Website`, and `License`.
* [x] I have read the instructions at https://github.com/micro-editor/plugin-channel#adding-your-own-plugin.

---

<!-- Other comments here -->
