### PR TITLE
Sniptab

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `jump`      | Jump to any function, class or heading with F4. Go, Markdown, Python, C and in 40 other languages | https://github.com/terokarvinen/micro-jump   | :heavy_check_mark:      |
 | `detectindent`  | Automatically detect indentation settings               | https://github.com/dmaluka/micro-detectindent              | :heavy_check_mark:                       |
 | `lsp`           | An basic LSP client implementation                      | https://github.com/AndCake/micro-plugin-lsp                | :heavy_check_mark:                       |
+| `sniptab`       | insert snippets, html-emmet or jsdoc-emmet to your file | https://github.com/gaenseklein/sniptab	                 | :heavy_check_mark:                       |
 
 
 ## Adding your own plugin

--- a/plugins/repo.json
+++ b/plugins/repo.json
@@ -1,0 +1,18 @@
+[
+	{
+		"Name": "sniptab",
+		"Description": "a simple snippets-plugin to let you insert vim-style snippets and emmets on current location",
+		"Tags": ["snippet", "emmet", "insert", "jsdoc"],
+        "Website": "https://github.com/gaenseklein/sniptab",
+        "License": "GPL3",
+		"Versions": [
+			{
+				"Version": "1.4.0",				
+				"Url": "https://github.com/gaenseklein/sniptab/archive/refs/tags/v1.4.0.zip",
+				"Require": {
+					"micro": ">=2.0.8"
+				}
+			}
+		]
+	}
+]

--- a/plugins/sniptab.json
+++ b/plugins/sniptab.json
@@ -8,7 +8,7 @@
 		"Versions": [
 			{
 				"Version": "1.4.0",				
-				"Url": "https://github.com/gaenseklein/sniptab/archive/refs/tags/v1.4.0.zip",
+				"Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/sniptab-1.4.0.zip",
 				"Require": {
 					"micro": ">=2.0.8"
 				}


### PR DESCRIPTION
This is a

* [x] New plugin.
* [ ] Update to an existing plugin.

Plugin name and version: sniptab v 1.4.0

Plugin source code zip file: [zip file](https://github.com/gaenseklein/sniptab/archive/refs/tags/v1.4.0.zip)

Checklist:

* [x] Plugin has a repo.json listing the `Name`, `Description`, `Website`, and `License`.
* [x] I have read the instructions at https://github.com/micro-editor/plugin-channel#adding-your-own-plugin.

---
sniptab is my personal replacement for the abandoned snippet-plugin (which did not work like i wanted it to). it has a different workflow, as it is used with only the tab-key (hence the name - if you have a better name please tell me). It is compatible with the syntax-files from the original snippet-plugin. 
sniptab also provides "emmet"-style html and jsdoc inserts (it creates snippets out of emmet-definition on the fly) as well as editing the corresponding .snippets-file from within micro-editor on the fly.
for more info check out https://github.com/gaenseklein/sniptab