### PR TITLE
Update editorconfig to v1.1.0

### DIFF
--- a/plugins/editorconfig-micro.json
+++ b/plugins/editorconfig-micro.json
@@ -6,6 +6,13 @@
   "License": "MIT",
   "Versions": [
     {
+      "Version": "1.1.0",
+      "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/editorconfig-micro-1.1.0.zip",
+      "Require": {
+        "micro": ">=2.0.1"
+      }
+    },
+    {
       "Version": "1.0.0",
       "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/editorconfig-micro-1.0.0.zip",
       "Require": {


### PR DESCRIPTION
This is a

* [ ] New plugin.
* [x] Update to an existing plugin.

Plugin name and version: editorconfig v1.1.0

Plugin source code zip file: https://github.com/10sr/editorconfig-micro/archive/v1.1.0.zip

<!-- In your PR, please list the zip file link as if it has been uploaded to https://github.com/micro-editor/plugin-channel/releases/tag/plugins. -->
<!-- If your plugin is approved, it will be uploaded there when merging the PR. -->

Checklist:

* [x] Plugin has a repo.json listing the `Name`, `Description`, `Website`, and `License`.
* [x] I have read the instructions at https://github.com/micro-editor/plugin-channel#adding-your-own-plugin.

---

The repository for this plugin is archived, but there was one release made more recent than the one currently in Micro. That release contains an important fix for Windows users and provides syntax highlighting for `.editorconfig` files.

<!-- Other comments here -->
