### PR TITLE
Add Code::Stats Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This repository contains the 'channel.json' file which lists all official micro 
 | `run`      | F5 to save and run, F12 to 'make', F9 to 'make' in background. Go, Python, Lua and executable file (#!) supported. Can 'make' whole project even from subdir. | https://github.com/terokarvinen/micro-run   | :heavy_check_mark:      |
 | `palettero`      | Command palette - Ctrl-P to fuzzy search & run commands, textfilters and descriptions. Use Python oneliners and grep to edit text. |  https://github.com/terokarvinen/palettero  | :heavy_check_mark:      |
 | `cheat`      | F1 cheatsheet for the language you're editing: Python, Go, Lua... |  https://github.com/terokarvinen/micro-cheat  | :heavy_check_mark:      |
+| `codestats`  | Code::Stats for Micro Editor                               | https://github.com/redfire75369/code-stats-micro           | :heavy_check_mark:                       |
 
 ## Adding your own plugin
 

--- a/channel.json
+++ b/channel.json
@@ -87,6 +87,9 @@
   "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/palettero.json",
 
   // cheat plugin
-  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-cheat.json"
+  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-cheat.json",
+
+  // codestats plugin
+  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/codestats.json"
 
 ]

--- a/plugins/codestats.json
+++ b/plugins/codestats.json
@@ -1,0 +1,15 @@
+[{
+  "Name": "codestats",
+  "Description": "Code::Stats Plugin for Micro",
+  "Website": "https://github.com/redfire75369/code-stats-micro",
+  "Tags": ["codestats", "stats"],
+  "Versions": [
+    {
+      "Version": "1.0.0",
+      "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/codestats-1.0.0.zip",
+      "Require": {
+        "Micro": ">2.0.0"
+      }
+    }
+  ]
+}]


### PR DESCRIPTION
This is a

* [X] New plugin.
* [ ] Update to an existing plugin.

Plugin name and version: codestats 1.0.0

Plugin source code zip file: https://github.com/redfire75369/code-stats-micro/archive/v1.0.0.zip

<!-- In your PR, please list the zip file link as if it has been uploaded to https://github.com/micro-editor/plugin-channel/releases/tag/plugins. -->
<!-- If your plugin is approved, it will be uploaded there when merging the PR. -->

Checklist:

* [X] Plugin has a repo.json listing the `Name`, `Description`, `Website`, and `License`.
* [X] I have read the instructions at https://github.com/micro-editor/plugin-channel#adding-your-own-plugin.

---

<!-- Other comments here -->
