### PR TITLE
Add Lotus theme plugin

### DIFF
--- a/plugins/lotus.json
+++ b/plugins/lotus.json
@@ -1,0 +1,34 @@
+[
+    {
+        "Name": "lotus",
+        "Description": "Lotus theme",
+        "Website": "https://github.com/finn-chipp/lotus",
+        "License": "GPLv3",
+
+        "Tags": [
+            "lotus",
+            "color",
+            "colors",
+            "colour",
+            "colours",
+            "syntax",
+            "theme",
+            "themes",
+            "highlighting",
+            "dark",
+            "colorscheme",
+            "colorschemes"
+        ],
+
+        "Versions": [
+            {
+                "Version": "1.0.0",
+                "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/lotus-1.0.0.zip",
+
+                "Require": {
+                    "micro": ">=1.1.3"
+                }
+            }
+        ]
+    }
+]


### PR DESCRIPTION
This is a

* [x] New plugin.
* [ ] Update to an existing plugin.

Plugin name and version: lotus-1.0.0

Plugin source code zip file: https://github.com/finn-chipp/lotus/archive/refs/tags/1.0.0.zip

<!-- In your PR, please list the zip file link as if it has been uploaded to https://github.com/micro-editor/plugin-channel/releases/tag/plugins. -->
<!-- If your plugin is approved, it will be uploaded there when merging the PR. -->

Checklist:

* [x] Plugin has a repo.json listing the `Name`, `Description`, `Website`, and `License`.
* [x] I have read the instructions at https://github.com/micro-editor/plugin-channel#adding-your-own-plugin.

---

<!-- Other comments here -->
