### PR TITLE
update wakatime plugin to latest version

### DIFF
--- a/plugins/micro-wakatime.json
+++ b/plugins/micro-wakatime.json
@@ -5,8 +5,8 @@
     "Tags": ["productivity", "time tracking", "project", "git", "timer"],
     "Versions": [
       {
-        "Version": "1.0.5",
-        "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/micro-wakatime-1.0.5.zip",
+        "Version": "1.0.6",
+        "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/micro-wakatime-1.0.6.zip",
         "Require": {
           "micro": ">=2.0.0"
         }


### PR DESCRIPTION
This is a

* [ ] New plugin.
* [x] Update to an existing plugin.

Plugin name and version: wakatime @ 1.0.6

Plugin source code zip file: https://github.com/wakatime/micro-wakatime/releases/tag/1.0.6

Checklist:

* [x] Plugin has a repo.json listing the `Name`, `Description`, `Website`, and `License`.
* [x] I have read the instructions at https://github.com/micro-editor/plugin-channel#adding-your-own-plugin.

---

<!-- Other comments here -->
