### PR TITLE
Update jlabbrev version 1.1.0

### DIFF
--- a/plugins/jlabbrev.json
+++ b/plugins/jlabbrev.json
@@ -3,10 +3,16 @@
 	"Description": "Julia backslash abbreviations in micro",
 	"Website": "https://github.com/MasFlam/jlabbrev",
 	"Tags": ["julia", "util"],
-    "License": "MIT",
+	"License": "MIT",
 	"Versions": [{
 		"Version": "1.0.1",
 		"Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/jlabbrev-1.0.1.zip",
+		"Require": {
+			"micro": ">=2.0"
+		}
+	}, {
+		"Version": "1.1.0",
+		"Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/jlabbrev-1.1.0.zip",
 		"Require": {
 			"micro": ">=2.0"
 		}


### PR DESCRIPTION
This is a

* [ ] New plugin.
* [x] Update to an existing plugin.

Plugin name and version: jlabbrev 1.1.0

Plugin source code zip file: https://github.com/MasFlam/jlabbrev/archive/refs/tags/v1.1.0.zip

<!-- In your PR, please list the zip file link as if it has been uploaded to https://github.com/micro-editor/plugin-channel/releases/tag/plugins. -->
<!-- If your plugin is approved, it will be uploaded there when merging the PR. -->

Checklist:

* [x] Plugin has a repo.json listing the `Name`, `Description`, `Website`, and `License`.
* [x] I have read the instructions at https://github.com/micro-editor/plugin-channel#adding-your-own-plugin.

---

<!-- Other comments here -->

Changelog:
- make the plugin stateless (the backslash is now searched for anew every time)
- add a common option `jlabbrev.enable` that controls whether any completion is attempted
