### PR TITLE
burixon-dark colorschemes

### DIFF
--- a/channel.json
+++ b/channel.json
@@ -87,6 +87,9 @@
   "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/palettero.json",
 
   // cheat plugin
-  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-cheat.json"
+  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/micro-cheat.json",
+
+  // burixon-dark colorschemes
+  "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/plugins/burixon-dark.json"
 
 ]

--- a/plugins/burixon-dark.json
+++ b/plugins/burixon-dark.json
@@ -9,7 +9,7 @@
     "Versions": [
       {
         "Version": "1.0.0",
-        "Url": "https://github.com/BuriXon-code/micro-burixon-dark/themes/burixon-dark.zip",
+        "Url": "https://github.com/micro-editor/plugin-channel/releases/download/plugins/burixon-dark-1.0.0.zip",
         "Require": {
           "micro": ">=1.1.3"
         }

--- a/plugins/burixon-dark.json
+++ b/plugins/burixon-dark.json
@@ -1,0 +1,19 @@
+[
+  {
+    "Name": "burixon-dark",
+    "Description": "A collection of beautiful themes for the Micro editor",
+    "Website": "https://github.com/BuriXon-code/micro-burixon-dark",
+    "Author": "BuriXon-code",
+    "Tags": ["colorscheme"],
+    "License": "MIT",
+    "Versions": [
+      {
+        "Version": "1.0.0",
+        "Url": "https://github.com/BuriXon-code/micro-burixon-dark/themes/burixon-dark.zip",
+        "Require": {
+          "micro": ">=1.1.3"
+        }
+      }
+    ]
+  }
+]


### PR DESCRIPTION
This is a

* [x] New plugin.
* [ ] Update to an existing plugin.

Plugin name and version: burixon-dark 1.0.0

Plugin source code zip file: https://github.com/BuriXon-code/micro-burixon-dark/raw/main/themes/burixon-dark.zip

<!-- In your PR, please list the zip file link as if it has been uploaded to https://github.com/micro-editor/plugin-channel/releases/tag/plugins. -->
<!-- If your plugin is approved, it will be uploaded there when merging the PR. -->

Checklist:

* [x] Plugin has a repo.json listing the `Name`, `Description`, `Website`, and `License`.
* [x] I have read the instructions at https://github.com/micro-editor/plugin-channel#adding-your-own-plugin.

---

<!-- Other comments here -->
Forgive me if I do something wrong and let me know what to fix.