### PR TITLE
Add version 0.0.9 of micro-run plugin (adds Rust support)

### DIFF
--- a/plugins/micro-run.json
+++ b/plugins/micro-run.json
@@ -6,6 +6,13 @@
   "License": "MIT license",
   "Versions": [
     {
+      "Version": "0.0.9",
+      "Url": "https://github.com/terokarvinen/micro-run/archive/v0.0.9.zip",
+      "Require": {
+        "micro": ">=2.0.0"
+      }
+    },   
+    {
       "Version": "0.0.8",
       "Url": "https://github.com/terokarvinen/micro-run/archive/v0.0.8.zip",
       "Require": {


### PR DESCRIPTION
This brings in Rust support for the micro-run/runit plugin.

This is a

* [ ] New plugin.
* [x] Update to an existing plugin.

Plugin name and version: 
* micro-run/runit version 0.09

Plugin source code zip file: (please upload a zip file or link a zip file).
* https://github.com/terokarvinen/micro-run/archive/v0.0.9.zip

<!-- In your PR, please list the zip file link as if it has been uploaded to https://github.com/micro-editor/plugin-channel/releases/tag/plugins. -->
<!-- If your plugin is approved, it will be uploaded there when merging the PR. -->

Checklist:

* [x] Plugin has a repo.json listing the `Name`, `Description`, `Website`, and `License`.
* [x] I have read the instructions at https://github.com/micro-editor/plugin-channel#adding-your-own-plugin.

---

<!-- Other comments here -->
